### PR TITLE
Set up release workflow

### DIFF
--- a/.github/scripts/workplace-snippet.sh
+++ b/.github/scripts/workplace-snippet.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Borrowed from rules_python
+
+set -o errexit -o nounset -o pipefail
+
+# Set by GH actions, see
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+TAG=${GITHUB_REF_NAME}
+PREFIX="bazel-snapshots-${TAG:1}"
+SHA=$(git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip | shasum -a 256 | awk '{print $1}')
+
+cat << EOF
+WORKSPACE setup:
+\`\`\`starlark
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "com_cognitedata_bazel_snapshots",
+    sha256 = "${SHA}",
+    strip_prefix = "${PREFIX}",
+    url = "https://github.com/cognitedata/bazel-snapshots/archive/refs/tags/${TAG}.tar.gz",
+)
+
+load("@com_cognitedata_bazel_snapshots//:repo.bzl", "snapshots_repos")
+snapshots_repos()
+\`\`\`
+EOF

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,48 @@
+# Cut a release whenever a new tag is pushed to the repo.
+name: Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Mount bazel cache
+        uses: actions/cache@v1
+        with:
+          path: "/home/runner/.cache/bazel"
+          key: bazel
+
+      - name: Run tests
+        run: |
+          bazel test //...
+
+      - name: Build linux-amd64
+        run: |
+          bazel build //snapshots/go/cmd/snapshots:snapshots-linux-amd64
+          mv bazel-bin/snapshots/go/cmd/snapshots/snapshots_/snapshots bazel-bin/snapshots-linux-amd64
+
+# Fails. Have to find out why.
+#      - name: Build darwin-amd64
+#        run: |
+#          bazel build //snapshots/go/cmd/snapshots:snapshots-darwin-amd64
+#          mv bazel-bin/snapshots/go/cmd/snapshots/snapshots_/snapshots bazel-bin/snapshots-darwin-amd64
+
+      - name: Prepare workspace snippet
+        run: |
+          bash .github/scripts/workplace-snippet.sh ${{ env.GITHUB_REF_NAME }} > release-notes.txt
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          body_path: release-notes.txt
+          files: |
+            bazel-bin/snapshots-*


### PR DESCRIPTION
Added release pipeline.
Darwin target doesn't work, so we'll have to figure out why. I think we should merge this as it's better to have a release pipeline that only builds for linux, than not to have a release pipeline at all.