### PR TITLE
Release archive with inserted sha256 sums

### DIFF
--- a/.github/scripts/workplace-snippet.sh
+++ b/.github/scripts/workplace-snippet.sh
@@ -4,11 +4,14 @@
 
 set -o errexit -o nounset -o pipefail
 
+[[ -z "$1" ]] && { echo "Repository URL is empty"; exit 1; }
+
+TARFILE="$1"
+
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}
-PREFIX="bazel-snapshots-${TAG}"
-SHA=$(git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip | shasum -a 256 | awk '{print $1}')
+SHA=$(shasum -a 256 $TARFILE | awk '{print $1}')
 
 cat << EOF
 WORKSPACE setup:
@@ -17,8 +20,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "com_cognitedata_bazel_snapshots",
     sha256 = "${SHA}",
-    strip_prefix = "${PREFIX}",
-    url = "https://github.com/cognitedata/bazel-snapshots/archive/refs/tags/${TAG}.tar.gz",
+    url = "https://github.com/cognitedata/bazel-snapshots/releases/download/${TAG}/snapshots-${TAG}.tar",
 )
 
 load("@com_cognitedata_bazel_snapshots//:repo.bzl", "snapshots_repos")

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      repoUrl: ${{ github.server_url }}/${{ github.repository }}
+      outputDir: ${{ github.workspace }}/bazel-snapshots-${{ github.ref_name }}
+      sourceTarName: snapshots-${{ github.ref_name }}.tar
 
     steps:
       - name: Checkout
@@ -27,11 +31,11 @@ jobs:
       - name: Build binaries
         run: |
           bazel build //snapshots/go/cmd/snapshots:snapshots
-          bazel run //tools:release -- ${{ github.ref_name }} ${{ github.workspace }}
+          bazel run //tools:release -- ${{ env.repoUrl }} ${{ github.ref_name }} ${{ env.outputDir }}
 
       - name: Prepare workspace snippet
         run: |
-          bash .github/scripts/workplace-snippet.sh ${{ github.ref_name }} > release-notes.txt
+          bash .github/scripts/workplace-snippet.sh ${{ env.outputDir }}/${{ env.sourceTarName }} > release-notes.txt
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -40,4 +44,4 @@ jobs:
           generate_release_notes: true
           body_path: release-notes.txt
           files: |
-            ${{ github.workspace }}/bazel-snapshots-${{ github.ref_name }}/*
+            ${{ env.outputDir }}/snapshots-*

--- a/repo.bzl
+++ b/repo.bzl
@@ -6,11 +6,11 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 # Pointing to the latest released binaries.
 URLS = {
     "darwin_amd64": {
-        "url": "https://github.com/cognitedata/bazel-snapshots/releases/download/v0.0.1/snapshots-darwin-amd64",
+        "url": "DARWIN_AMD64_URL",
         "sha256": "DARWIN_AMD64_SHA256",
     },
     "linux_amd64": {
-        "url": "https://github.com/cognitedata/bazel-snapshots/releases/download/v0.0.1/snapshots-linux-amd64",
+        "url": "LINUX_AMD64_URL",
         "sha256": "LINUX_AMD64_SHA256",
     }
 }

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -2,12 +2,23 @@
 
 set -e
 
-[[ -z "$1" ]] && { echo "Version is empty"; exit 1; }
+[[ -z "$1" ]] && { echo "Repository URL is empty"; exit 1; }
 
-[[ -z "$2" ]] && { echo "Output path is empty"; exit 1; }
+[[ -z "$2" ]] && { echo "Version is empty"; exit 1; }
 
-VERSION="$1"
-OUT_DIR="$2/bazel-snapshots-$VERSION"
+[[ -z "$3" ]] && { echo "Output path is empty"; exit 1; }
+
+REPOSITORY="$1"
+VERSION="$2"
+OUT_DIR="$3"
+
+DARWIN_AMD64_FILENAME="snapshots-darwin-amd64"
+DARWIN_AMD64_URL="$REPOSITORY/releases/download/$VERSION/$DARWIN_AMD64_FILENAME"
+ESCAPED_DARWIN_AMD64_URL=$(printf '%s\n' "$DARWIN_AMD64_URL" | sed -e 's/[\/&]/\\&/g')
+
+LINUX_AMD64_FILENAME="snapshots-linux-amd64"
+LINUX_AMD64_URL="$REPOSITORY/releases/download/$VERSION/$LINUX_AMD64_FILENAME"
+ESCAPED_LINUX_AMD64_URL=$(printf '%s\n' "$LINUX_AMD64_URL" | sed -e 's/[\/&]/\\&/g')
 
 mkdir -p "$OUT_DIR"
 
@@ -15,16 +26,27 @@ mkdir -p "$OUT_DIR"
 tar -cvf "$OUT_DIR/snapshots-$VERSION.tar" -C "$BUILD_WORKSPACE_DIRECTORY" snapshots deps.bzl BUILD.bazel WORKSPACE README.md LICENSE
 
 # copy binaries to output folder
-cp "snapshots/go/cmd/snapshots/snapshots-darwin-amd64_/snapshots-darwin-amd64" "$OUT_DIR/snapshots-darwin-amd64"
-cp "snapshots/go/cmd/snapshots/snapshots-linux-amd64_/snapshots-linux-amd64" "$OUT_DIR/snapshots-linux-amd64"
+cp "snapshots/go/cmd/snapshots/snapshots-darwin-amd64_/$DARWIN_AMD64_FILENAME" "$OUT_DIR/$DARWIN_AMD64_FILENAME"
+cp "snapshots/go/cmd/snapshots/snapshots-linux-amd64_/$LINUX_AMD64_FILENAME" "$OUT_DIR/$LINUX_LINUX_AMD64_FILENAME"
+
+# generate sha files
+(cd $OUT_DIR ; shasum -a 256 "$DARWIN_AMD64_FILENAME" > "$DARWIN_AMD64_FILENAME.sha256")
+(cd $OUT_DIR ; shasum -a 256 "$LINUX_AMD64_FILENAME" > "$LINUX_AMD64_FILENAME.sha256")
 
 # find shasums
-DARWIN_AMD64_SHA256=$(shasum -a 256 "$OUT_DIR/snapshots-darwin-amd64" | cut -d " " -f 1)
-LINUX_AMD64_SHA256=$(shasum -a 256 "$OUT_DIR/snapshots-linux-amd64" | cut -d " " -f 1)
+DARWIN_AMD64_SHA256=$(shasum -a 256 "$OUT_DIR/$DARWIN_AMD64_FILENAME" | cut -d " " -f 1)
+LINUX_AMD64_SHA256=$(shasum -a 256 "$OUT_DIR/$LINUX_AMD64_FILENAME" | cut -d " " -f 1)
 
-# replace shasums in repo.bzl and add to the archive
+# replace urls in repo.bzl
 sed \
-    "s/DARWIN_AMD64_SHA256/$DARWIN_AMD64_SHA256/g; s/LINUX_AMD64_SHA256/$LINUX_AMD64_SHA256/g" \
+    "s/DARWIN_AMD64_URL/$ESCAPED_DARWIN_AMD64_URL/g; s/LINUX_AMD64_URL/$ESCAPED_LINUX_AMD64_URL/g" \
     "$BUILD_WORKSPACE_DIRECTORY/repo.bzl" \
     > "$OUT_DIR/repo.bzl"
+
+# replace shasums in repo.bzl
+sed -i \
+    "s/DARWIN_AMD64_SHA256/$DARWIN_AMD64_SHA256/g; s/LINUX_AMD64_SHA256/$LINUX_AMD64_SHA256/g" \
+    "$OUT_DIR/repo.bzl"
+
+# add to the archive
 tar --append -C "$OUT_DIR" --file="$OUT_DIR/snapshots-$VERSION.tar" "repo.bzl"


### PR DESCRIPTION
@mortenmj Will need some adjustments to `workplace-snippet.sh` too. This tarball should be the one to be downloaded, instead of the tarball by github for the tag.