### PR TITLE
Run CI workflow on pull_request.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,6 @@
 name: ci
 
-on:
-  push: {}
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
By default, the 'opened', 'synchronize' and 'reopened' activities trigger the 'pull_request' event.