### PR TITLE
Basic Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true
+    }
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "bazel run gazelle-update-repos",
+    ],
+    "fileFilters": [
+      "**/*.bzl",
+    ],
+    "executionMode": "branch"
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
This does a few things:

- Move renovate.json to .github/ for a cleaner project root
- Change renovate.json to renovate.json5, to support json with comments
- Set autoMerge for digest, pin and patch versions (i.e. not minor and major for now)
- Automatically run gazelle-update-repos after bazel updates