### PR TITLE
Allow change_tracker to track source files

### DIFF
--- a/examples/change-tracker/BUILD.bazel
+++ b/examples/change-tracker/BUILD.bazel
@@ -28,5 +28,13 @@ change_tracker(
     name = "artifact_change_tracker",
     deps = [":artifact"],
     run = [":deploy"],
-    tracker_tags = ["deployable"],
+    tracker_tags = ["deployable_artifact"],
+)
+
+# You can also track source file that aren't targets coming from other rules
+change_tracker(
+    name = "source_file_change_tracker",
+    deps = ["source_file_1.txt"],
+    run = [":deploy"],
+    tracker_tags = ["deployable_source_file"],
 )

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -89,7 +89,7 @@ _change_tracker = rule(
         "run": attr.label_list(
             doc = "List of executable targets to run when there are changes to deps",
         ),
-        "deps": attr.label_list(),
+        "deps": attr.label_list(allow_files = True),
         "tracker_tags": attr.string_list(
             doc = "Tags for the tracker",
         ),


### PR DESCRIPTION
Fixes #60 

## Changes
* Allow `change_tracker` to track source files by setting `allow_files`
* Modify change tracker example to show how this works