### PR TITLE
Set 'json' as default output format for the diff command

### DIFF
--- a/snapshots/go/cmd/snapshots/diff.go
+++ b/snapshots/go/cmd/snapshots/diff.go
@@ -49,7 +49,7 @@ func (*diffConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Con
 	dc := &diffConfig{}
 	c.Exts[diffName] = dc
 	fs.BoolVar(&dc.stderrPretty, "stderr-pretty", false, "pretty-print in stderr in addition")
-	fs.StringVar(&dc.outputFormat, "format", outputLabel, "output format (label, json, pretty)")
+	fs.StringVar(&dc.outputFormat, "format", outputJSON, "output format (label, json, pretty)")
 }
 
 func (*diffConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error {


### PR DESCRIPTION
The only usecases we have so far use JSON as output, which is also
much more versatile, as it outputs the tags, the kind of change, etc.
Flipping the flag, so that JSON becomes the default, and users wanting
just the plain labels can use `--format=label".

Affects #65 