### PR TITLE
Remove workspace name setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ in your root BUILD file:
 ```skylark
 snapshots(
     name = "snapshots",
-    storage = "gcs://name/of/the/storage?credential=env&project_id=env",
+    storage = "gcs://my-bucket/some-path/?credential=env&project_id=env",
 )
 ```
 
-Google Cloud Storage requires `credential` and `project_id` fields to be exists in the storage url.
-You can set both values to env in order to use the default credentials and automatically infer the project ID.
+Google Cloud Storage requires `credential` and `project_id` fields to be defined as query parameters in the storage url.
+You can set both values to `env` in order to use the default credentials and automatically infer the project ID.
 
 > :warning: **Make sure to provide full path of the storage.** Each supported backend has their own
 set of variables that you can find in the below table.

--- a/snapshots/go/cmd/snapshots/config.go
+++ b/snapshots/go/cmd/snapshots/config.go
@@ -15,9 +15,8 @@ import (
 // commonConfig holds common configuration for all commands; args which can
 // always be passed.
 type commonConfig struct {
-	storageURL    string
-	workspaceName string
-	verbose       bool
+	storageURL string
+	verbose    bool
 }
 
 const commonName = "_common"
@@ -32,7 +31,6 @@ func (*commonConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.C
 	cc := &commonConfig{}
 	c.Exts[commonName] = cc
 	fs.StringVar(&cc.storageURL, "storage-url", "", "full orl of the storage")
-	fs.StringVar(&cc.workspaceName, "workspace-name", "", "name of bazel workspace")
 	fs.BoolVar(&cc.verbose, "verbose", false, "verbose output")
 }
 

--- a/snapshots/go/cmd/snapshots/get.go
+++ b/snapshots/go/cmd/snapshots/get.go
@@ -94,7 +94,7 @@ func get(ctx context.Context, gc *getConfig) (*models.Snapshot, error) {
 	var snapshotName string
 
 	if !gc.skipTags {
-		tagPath := fmt.Sprintf("%s/tags/%s", gc.workspaceName, gc.name)
+		tagPath := fmt.Sprintf("tags/%s", gc.name)
 		tagBuffer := new(bytes.Buffer)
 		_, err := store.StatWithContext(ctx, tagPath)
 		if err == nil {
@@ -108,7 +108,7 @@ func get(ctx context.Context, gc *getConfig) (*models.Snapshot, error) {
 			}
 			snapshotName = string(snapshotBytes)
 
-			_, err = store.ReadWithContext(ctx, fmt.Sprintf("%s/snapshots/%s.json", gc.workspaceName, snapshotName), snapshotBuffer)
+			_, err = store.ReadWithContext(ctx, fmt.Sprintf("snapshots/%s.json", snapshotName), snapshotBuffer)
 			if err != nil {
 				return nil, fmt.Errorf("failed to find resolved snapshot %s: %w", snapshotName, err)
 			}
@@ -116,12 +116,12 @@ func get(ctx context.Context, gc *getConfig) (*models.Snapshot, error) {
 	}
 
 	if !gc.skipNames && snapshotBuffer.Len() == 0 {
-		it, err := store.List(fmt.Sprintf("%s/snapshots/%s", gc.workspaceName, gc.name))
+		it, err := store.List(fmt.Sprintf("snapshots/%s", gc.name))
 		if err != nil {
 			return nil, fmt.Errorf("cannot create object iterator: %w", err)
 		}
 		if attrs, err := it.Next(); err != nil && errors.Is(err, storage.IteratorDone) {
-			return nil, fmt.Errorf("failed to look for snapshot")
+			return nil, fmt.Errorf("failed to look for snapshot %s in %s", gc.name, store.String())
 		} else if err == nil {
 			if _, err := it.Next(); err == nil {
 				return nil, fmt.Errorf("ambiguous snapshot name: %s", gc.name)
@@ -129,7 +129,7 @@ func get(ctx context.Context, gc *getConfig) (*models.Snapshot, error) {
 			snapshotName = strings.TrimSuffix(path.Base(attrs.Path), ".json")
 		}
 
-		_, err = store.ReadWithContext(ctx, fmt.Sprintf("%s/snapshots/%s.json", gc.workspaceName, snapshotName), snapshotBuffer)
+		_, err = store.ReadWithContext(ctx, fmt.Sprintf("snapshots/%s.json", snapshotName), snapshotBuffer)
 		if err != nil {
 			return nil, fmt.Errorf("cannot read the snapshot: %w", err)
 		}

--- a/snapshots/go/cmd/snapshots/push.go
+++ b/snapshots/go/cmd/snapshots/push.go
@@ -105,9 +105,9 @@ func runPush(args []string) error {
 	}
 
 	contentLenght, isOk := obj.GetContentLength()
-		if !isOk {
-			log.Printf("failed to get contentLenght of pushed snapshot: %s", obj.Path)
-		}
+	if !isOk {
+		log.Printf("failed to get contentLenght of pushed snapshot: %s", obj.Path)
+	}
 
 	log.Printf("pushed snapshot of %d bytes: %s", contentLenght, obj.Path)
 
@@ -129,7 +129,7 @@ func push(ctx context.Context, pc *pushConfig) (*types.Object, error) {
 		return nil, fmt.Errorf("failed to create storage client: %w", err)
 	}
 
-	location := fmt.Sprintf("%s/snapshots/%s.json", pc.workspaceName, pc.name)
+	location := fmt.Sprintf("snapshots/%s.json", pc.name)
 	reader := bytes.NewReader(snapshotBytes)
 	if _, err := store.WriteWithContext(ctx, location, reader, int64(reader.Len())); err != nil {
 		return nil, fmt.Errorf("failed to write to bucket file: %w", err)

--- a/snapshots/go/cmd/snapshots/tag.go
+++ b/snapshots/go/cmd/snapshots/tag.go
@@ -97,7 +97,7 @@ func tag(ctx context.Context, tc *tagConfig) (*types.Object, error) {
 		return nil, fmt.Errorf("failed to create storage client: %w", err)
 	}
 
-	snapshotLocation := fmt.Sprintf("%s/snapshots/%s.json", tc.workspaceName, tc.snapshotName)
+	snapshotLocation := fmt.Sprintf("snapshots/%s.json", tc.snapshotName)
 
 	attrs, err := store.StatWithContext(ctx, snapshotLocation)
 	if err != nil {
@@ -105,7 +105,7 @@ func tag(ctx context.Context, tc *tagConfig) (*types.Object, error) {
 	}
 
 	tagContent := []byte(strings.TrimSuffix(path.Base(attrs.Path), ".json"))
-	tagLocation := fmt.Sprintf("%s/tags/%s", tc.workspaceName, tc.tagName)
+	tagLocation := fmt.Sprintf("tags/%s", tc.tagName)
 	reader := bytes.NewReader(tagContent)
 
 	if _, err := store.WriteWithContext(ctx, tagLocation, reader, int64(reader.Len())); err != nil {

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -104,7 +104,6 @@ def change_tracker(name, **kwargs):
 
 def _snapshots_runner_impl(ctx):
     args = []
-    args.extend(["--workspace-name", ctx.workspace_name])
     args.extend(["--storage-url", ctx.attr.storage])
 
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")


### PR DESCRIPTION
Let users control the full path in the storage instead of magically
using the workspace name. The path inside the bucket can be controlled
through the 'storage' attribute.

Example:

```skylark
snapshots(
    name = "snapshots",
    storage = "gcs://some-bucket/my-workspace/?credential=env&project_id=env",
)
```

BREAKING CHANGES:
 * no longer automatically sets path in remote storage

Fixes #66 