### PR TITLE
Set 'env' values in storage query values by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,20 +109,16 @@ in your root BUILD file:
 ```skylark
 snapshots(
     name = "snapshots",
-    storage = "gcs://my-bucket/some-path/?credential=env&project_id=env",
+    storage = "gcs://some-bucket/workspace-name",
 )
 ```
 
-Google Cloud Storage requires `credential` and `project_id` fields to be defined as query parameters in the storage url.
-You can set both values to `env` in order to use the default credentials and automatically infer the project ID.
+Google Cloud Storage optionally takes `credential` and `project_id` query parameters in the storage URL.
+If not set, the default credentials will be used and the project ID will be inferred.
 
-> :warning: **Make sure to provide full path of the storage.** Each supported backend has their own
-set of variables that you can find in the below table.
-
-Backend | Variables | Values
+Backend | Docs | Notes
 ---|---|---
-Google Cloud Storage | `credential`<br> `project_id` | `env` _or_ `"~/path/to/credential.json"`<br> `env` _or_ `"project_id"`
-
+Google Cloud Storage | [gcs](https://beyondstorage.io/docs/go-storage/services/gcs#storager) | `credential` and `project_id` defaults to `env`
 
 Bazel Snapshots will create the following structure in the remote storage:
 

--- a/snapshots/go/pkg/storage/storage.go
+++ b/snapshots/go/pkg/storage/storage.go
@@ -3,6 +3,10 @@
 package storage
 
 import (
+	"fmt"
+	"net/url"
+	"strings"
+
 	_ "go.beyondstorage.io/services/gcs/v3"
 	"go.beyondstorage.io/v5/services"
 	"go.beyondstorage.io/v5/types"
@@ -10,6 +14,34 @@ import (
 
 var IteratorDone = types.IterateDone
 
-func NewStorage(storageUrl string) (types.Storager, error) {
-	return services.NewStoragerFromString(storageUrl)
+func NewStorage(storageURL string) (types.Storager, error) {
+	u, err := url.Parse(storageURL)
+	if err != nil {
+		return nil, err
+	}
+
+	values := u.Query()
+
+	// automatically fix the storage URL for common problems
+	if u.Scheme == "gcs" {
+		// set default value for 'credential' if not set: will use default
+		// credentials.
+		if values.Get("credential") == "" {
+			values.Add("credential", "env")
+		}
+
+		// set default value for 'project_id' if not set: will be inferred.
+		if values.Get("project_id") == "" {
+			values.Add("project_id", "env")
+		}
+
+		// make sure path ends with a '/'
+		if !strings.HasSuffix(u.Path, "/") {
+			u.Path = fmt.Sprintf("%s/", u.Path)
+		}
+	}
+
+	u.RawQuery = values.Encode()
+
+	return services.NewStoragerFromString(u.String())
 }


### PR DESCRIPTION
If not otherwise specified, set the value of `credential` and
`project_id` to be `env` for GCS.