### PR TITLE
Add arg structs 

### DIFF
--- a/snapshots/go/cmd/snapshots/collect.go
+++ b/snapshots/go/cmd/snapshots/collect.go
@@ -70,6 +70,7 @@ func runCollect(args []string) error {
 	cc := getCollectConfig(c)
 
 	log.Println("bazel path:      ", cc.bazelPath)
+	log.Println("bazelRc path:    ", cc.bazelRcPath)
 	log.Println("workspace path:  ", cc.workspacePath)
 	log.Println("query expression:", cc.queryExpression)
 	log.Println("out path:        ", cc.outPath)

--- a/snapshots/go/cmd/snapshots/collect.go
+++ b/snapshots/go/cmd/snapshots/collect.go
@@ -74,15 +74,17 @@ func runCollect(args []string) error {
 	log.Println("query expression:", cc.queryExpression)
 	log.Println("out path:        ", cc.outPath)
 
-	// run the command
-	if _, err := collecter.NewCollecter().Collect(
-		cc.bazelPath,
-		cc.outPath,
-		cc.queryExpression,
-		cc.workspacePath,
-		cc.bazelCacheGRPCInsecure,
-		cc.bazelStderr,
-		cc.noPrint); err != nil {
+	collectArgs := collecter.CollectArgs{
+		BazelCacheGrpcInsecure: cc.bazelCacheGRPCInsecure,
+		BazelExpression:        cc.queryExpression,
+		BazelPath:              cc.bazelPath,
+		BazelRcPath:            cc.bazelRcPath,
+		BazelWorkspacePath:     cc.workspacePath,
+		BazelWriteStderr:       cc.bazelStderr,
+		OutPath:                cc.outPath,
+		NoPrint:                cc.noPrint,
+	}
+	if _, err := collecter.NewCollecter().Collect(&collectArgs); err != nil {
 		return fmt.Errorf("failed to collect: %w", err)
 	}
 

--- a/snapshots/go/cmd/snapshots/config.go
+++ b/snapshots/go/cmd/snapshots/config.go
@@ -57,6 +57,7 @@ func (*bazelConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Co
 	bc := &bazelConfig{}
 	c.Exts[bazelName] = bc
 	fs.StringVar(&bc.bazelPath, "bazel_path", "", "bazel path (defaults to lookup)")
+	fs.StringVar(&bc.bazelRcPath, "bazelrc", "", "bazelrc (defaults to workspace_path/.bazelrc)")
 	fs.StringVar(&bc.workspacePath, "workspace_path", "", "workspace path (defaults to BUILD_WORKSPACE_DIRECTORY)")
 }
 
@@ -76,6 +77,10 @@ func (*bazelConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) (err erro
 		} else {
 			return fmt.Errorf("-workspace_path not specified and BUILD_WORKSPACE_DIRECTORY not set")
 		}
+	}
+
+	if bc.bazelRcPath == "" {
+		bc.bazelRcPath = fmt.Sprintf("%s/.bazelrc", bc.workspacePath)
 	}
 
 	return

--- a/snapshots/go/cmd/snapshots/config.go
+++ b/snapshots/go/cmd/snapshots/config.go
@@ -57,7 +57,7 @@ func (*bazelConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Co
 	bc := &bazelConfig{}
 	c.Exts[bazelName] = bc
 	fs.StringVar(&bc.bazelPath, "bazel_path", "", "bazel path (defaults to lookup)")
-	fs.StringVar(&bc.bazelRcPath, "bazelrc", "", "bazelrc (defaults to workspace_path/.bazelrc)")
+	fs.StringVar(&bc.bazelRcPath, "bazelrc", "", "bazelrc (defaults to none")
 	fs.StringVar(&bc.workspacePath, "workspace_path", "", "workspace path (defaults to BUILD_WORKSPACE_DIRECTORY)")
 }
 
@@ -77,10 +77,6 @@ func (*bazelConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) (err erro
 		} else {
 			return fmt.Errorf("-workspace_path not specified and BUILD_WORKSPACE_DIRECTORY not set")
 		}
-	}
-
-	if bc.bazelRcPath == "" {
-		bc.bazelRcPath = fmt.Sprintf("%s/.bazelrc", bc.workspacePath)
 	}
 
 	return

--- a/snapshots/go/cmd/snapshots/config.go
+++ b/snapshots/go/cmd/snapshots/config.go
@@ -41,6 +41,7 @@ func (*commonConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 // bazelConfig holds values useful for interacting with Bazel
 type bazelConfig struct {
 	bazelPath     string
+	bazelRcPath   string
 	workspacePath string
 }
 

--- a/snapshots/go/cmd/snapshots/digest.go
+++ b/snapshots/go/cmd/snapshots/digest.go
@@ -58,7 +58,13 @@ func runDigest(args []string) (err error) {
 
 	dc := getDigestConfig(c)
 
-	return digester.NewDigester().Digest(dc.inPaths, dc.run, dc.tags, dc.outPath)
+	digestArgs := digester.DigestArgs{
+		InPaths: dc.inPaths,
+		Run:     dc.run,
+		Tags:    dc.tags,
+		OutPath: dc.outPath,
+	}
+	return digester.NewDigester().Digest(&digestArgs)
 }
 
 func digestUsage(fs *flag.FlagSet) {

--- a/snapshots/go/cmd/snapshots/get.go
+++ b/snapshots/go/cmd/snapshots/get.go
@@ -64,7 +64,13 @@ func runGet(args []string) error {
 
 	gc := getGetConfig(c)
 
-	snapshot, err := getter.NewGetter().Get(ctx, gc.name, gc.storageURL, gc.skipNames, gc.skipTags)
+	getArgs := getter.GetArgs{
+		Name: gc.name,
+		StorageUrl: gc.storageURL,
+		SkipNames: gc.skipNames,
+		SkipTags: gc.skipTags,
+	}
+	snapshot, err := getter.NewGetter().Get(ctx, &getArgs)
 	if err != nil {
 		return err
 	}

--- a/snapshots/go/cmd/snapshots/push.go
+++ b/snapshots/go/cmd/snapshots/push.go
@@ -97,7 +97,12 @@ func runPush(args []string) error {
 	log.Printf("workspace: %s", pc.workspacePath)
 	log.Printf("storage:    %s", pc.storageURL)
 
-	obj, err := pusher.NewPusher().Push(ctx, pc.name, pc.storageURL, pc.snapshot)
+	pushArgs := pusher.PushArgs{
+		Name: pc.name,
+		StorageUrl: pc.storageURL,
+		Snapshot: pc.snapshot,
+	}
+	obj, err := pusher.NewPusher().Push(ctx, &pushArgs)
 	if err != nil {
 		return err
 	}

--- a/snapshots/go/cmd/snapshots/tag.go
+++ b/snapshots/go/cmd/snapshots/tag.go
@@ -77,7 +77,12 @@ func runTag(args []string) error {
 	log.Printf("snapshot:  %s", tc.snapshotName)
 	log.Printf("tag:       %s", tc.tagName)
 
-	obj, err := tagger.NewTagger().Tag(ctx, tc.storageURL, tc.snapshotName, tc.tagName)
+	tagArgs := tagger.TagArgs{
+		SnapshotName: tc.snapshotName,
+		StorageUrl: tc.storageURL,
+		TagName: tc.tagName,
+	}
+	obj, err := tagger.NewTagger().Tag(ctx, &tagArgs)
 	if err != nil {
 		return err
 	}

--- a/snapshots/go/pkg/bazel/bazel.go
+++ b/snapshots/go/pkg/bazel/bazel.go
@@ -33,8 +33,6 @@ func NewClient(path, ws string, stderr io.Writer) *Client {
 func (c *Client) Command(ctx context.Context, args ...string) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
 
-	fmt.Printf("args: %v", args)
-
 	cmd := exec.CommandContext(ctx, c.path, args...)
 	cmd.Stderr = c.stderr
 	cmd.Stdout = buf
@@ -58,7 +56,7 @@ func (c *Client) BuildEventOutput(ctx context.Context, bazelrc string, args ...s
 	args = append([]string{"build", fmt.Sprintf("--build_event_json_file=%s", f.Name())}, args...)
 
 	if bazelrc != "" {
-		args = append([]string {fmt.Sprintf("--bazelrc=%s", bazelrc)}, args...)
+		args = append([]string{fmt.Sprintf("--bazelrc=%s", bazelrc)}, args...)
 	}
 
 	if _, err := c.Command(ctx, args...); err != nil {

--- a/snapshots/go/pkg/bazel/bazel.go
+++ b/snapshots/go/pkg/bazel/bazel.go
@@ -33,6 +33,8 @@ func NewClient(path, ws string, stderr io.Writer) *Client {
 func (c *Client) Command(ctx context.Context, args ...string) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
 
+	fmt.Printf("args: %v", args)
+
 	cmd := exec.CommandContext(ctx, c.path, args...)
 	cmd.Stderr = c.stderr
 	cmd.Stdout = buf
@@ -45,7 +47,7 @@ func (c *Client) Command(ctx context.Context, args ...string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (c *Client) BuildEventOutput(ctx context.Context, args ...string) ([]BuildEventOutput, error) {
+func (c *Client) BuildEventOutput(ctx context.Context, bazelrc string, args ...string) ([]BuildEventOutput, error) {
 	// create a temporary file
 	f, err := os.CreateTemp("", "snapshots-collect")
 	if err != nil {
@@ -54,6 +56,10 @@ func (c *Client) BuildEventOutput(ctx context.Context, args ...string) ([]BuildE
 	defer os.Remove(f.Name())
 
 	args = append([]string{"build", fmt.Sprintf("--build_event_json_file=%s", f.Name())}, args...)
+
+	if bazelrc != "" {
+		args = append([]string {fmt.Sprintf("--bazelrc=%s", bazelrc)}, args...)
+	}
 
 	if _, err := c.Command(ctx, args...); err != nil {
 		return nil, fmt.Errorf("failed to build: %w", err)

--- a/snapshots/go/pkg/collecter/collecter.go
+++ b/snapshots/go/pkg/collecter/collecter.go
@@ -75,11 +75,7 @@ func (c *collecter) Collect(args *CollectArgs) (*models.Snapshot, error) {
 	log.Printf("collecting digests from %s", args.BazelExpression)
 	bazelArgs := []string{args.BazelExpression, "--output_groups=change_track_files"}
 
-	if args.BazelRcPath != "" {
-		bazelArgs = append(bazelArgs, fmt.Sprintf("--bazelrc=%s", args.BazelRcPath))
-	}
-
-	buildEvents, err := bazelc.BuildEventOutput(ctx, bazelArgs...)
+	buildEvents, err := bazelc.BuildEventOutput(ctx, args.BazelRcPath, bazelArgs...)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshots/go/pkg/collecter/collecter.go
+++ b/snapshots/go/pkg/collecter/collecter.go
@@ -23,46 +23,63 @@ func NewCollecter() *collecter {
 	return &collecter{}
 }
 
+type CollectArgs struct {
+	BazelCacheGrpcInsecure bool
+	BazelExpression        string
+	BazelPath              string
+	BazelRcPath            string
+	BazelWorkspacePath     string
+	BazelWriteStderr       bool
+	OutPath                string
+	NoPrint                bool
+}
+
 // collect uses Bazel directly to build and collect all change tracker files to
 // compose a snapshot. It first runs 'bazel build' with a query expression, e.g.
 // '//...', with the change_track_files output groups, while also capturing
 // build events (see Bazel's --build_event_json_file). It then retrieves all
 // these tracker files, parses them and builds the snapshot.
-func (c *collecter) Collect(bazelPath, outPath, queryExpression, workspacePath string, bazelCacheGrpcInsecure, bazelStderr, noPrint bool) (*models.Snapshot, error) {
-	if bazelPath == "" {
+func (c *collecter) Collect(args *CollectArgs) (*models.Snapshot, error) {
+	if args.BazelPath == "" {
 		path, err := exec.LookPath("bazel")
 		if err != nil {
 			return nil, err
 		}
 
-		bazelPath = path
+		args.BazelPath = path
 	}
 
-	if workspacePath == "" {
+	if args.BazelWorkspacePath == "" {
 		if wsDir := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); wsDir != "" {
-			workspacePath = wsDir
+			args.BazelWorkspacePath = wsDir
 		} else {
 			return nil, fmt.Errorf("workspace-path not specified and BUILD_WORKSPACE_DIRECTORY not set")
 		}
 	}
 
 	dialOptions := []grpc.DialOption{}
-	if bazelCacheGrpcInsecure {
+	if args.BazelCacheGrpcInsecure {
 		dialOptions = append(dialOptions, grpc.WithInsecure())
 	}
 
 	bstderr := io.Discard
-	if bazelStderr {
+	if args.BazelWriteStderr {
 		bstderr = os.Stderr
 	}
 
 	ctx := context.Background()
-	bazelc := bazel.NewClient(bazelPath, workspacePath, bstderr)
+	bazelc := bazel.NewClient(args.BazelPath, args.BazelWorkspacePath, bstderr)
 	bcache := bazel.NewDefaultDelegatingCache(dialOptions)
 
 	// build digests, get the build events
-	log.Printf("collecting digests from %s", queryExpression)
-	buildEvents, err := bazelc.BuildEventOutput(ctx, queryExpression, "--output_groups=change_track_files")
+	log.Printf("collecting digests from %s", args.BazelExpression)
+	bazelArgs := []string{args.BazelExpression, "--output_groups=change_track_files"}
+
+	if args.BazelRcPath != "" {
+		bazelArgs = append(bazelArgs, fmt.Sprintf("--bazelrc=%s", args.BazelRcPath))
+	}
+
+	buildEvents, err := bazelc.BuildEventOutput(ctx, bazelArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -113,9 +130,9 @@ func (c *collecter) Collect(bazelPath, outPath, queryExpression, workspacePath s
 		return nil, fmt.Errorf("failed to marshal manifest JSON: %w", err)
 	}
 
-	if outPath != "" {
+	if args.OutPath != "" {
 		// write to outpath
-		outFile, err := os.Create(outPath)
+		outFile, err := os.Create(args.OutPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open out path: %w", err)
 		}
@@ -125,7 +142,8 @@ func (c *collecter) Collect(bazelPath, outPath, queryExpression, workspacePath s
 		}
 		log.Printf("wrote file to %s", outFile.Name())
 	}
-	if outPath == "" && !noPrint {
+
+	if args.OutPath == "" && !args.NoPrint {
 		// write to stdout
 		if _, err := io.Copy(os.Stdout, bytes.NewBuffer(snapshotJSON)); err != nil {
 			return nil, err

--- a/snapshots/go/pkg/digester/digester.go
+++ b/snapshots/go/pkg/digester/digester.go
@@ -19,17 +19,24 @@ func NewDigester() *digester {
 	return &digester{}
 }
 
-func (d *digester) Digest(inPaths, run, tags []string, outPath string) error {
+type DigestArgs struct {
+	InPaths []string
+	Run     []string
+	Tags    []string
+	OutPath string
+}
+
+func (d *digester) Digest(args *DigestArgs) error {
 	// sort the input files for more stability
-	sort.Strings(inPaths)
+	sort.Strings(args.InPaths)
 
 	ct := &models.Tracker{
-		Run:  run,
-		Tags: tags,
+		Run:  args.Run,
+		Tags: args.Tags,
 	}
 
 	h := sha256.New()
-	for _, input := range inPaths {
+	for _, input := range args.InPaths {
 		// add the filename
 		h.Write([]byte(path.Base(input)))
 
@@ -51,5 +58,5 @@ func (d *digester) Digest(inPaths, run, tags []string, outPath string) error {
 		return fmt.Errorf("failed to render json file: %w", err)
 	}
 
-	return ioutil.WriteFile(outPath, content, 0644)
+	return ioutil.WriteFile(args.OutPath, content, 0644)
 }

--- a/snapshots/go/pkg/tagger/tagger.go
+++ b/snapshots/go/pkg/tagger/tagger.go
@@ -18,13 +18,19 @@ func NewTagger() *tagger {
 	return &tagger{}
 }
 
-func (*tagger) Tag(ctx context.Context, storageUrl, snapshotName, tagName string) (*types.Object, error) {
-	store, err := storage.NewStorage(storageUrl)
+type TagArgs struct {
+	SnapshotName string
+	StorageUrl   string
+	TagName      string
+}
+
+func (*tagger) Tag(ctx context.Context, args *TagArgs) (*types.Object, error) {
+	store, err := storage.NewStorage(args.StorageUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage client: %w", err)
 	}
 
-	snapshotLocation := fmt.Sprintf("snapshots/%s.json", snapshotName)
+	snapshotLocation := fmt.Sprintf("snapshots/%s.json", args.SnapshotName)
 
 	attrs, err := store.StatWithContext(ctx, snapshotLocation)
 	if err != nil {
@@ -32,7 +38,7 @@ func (*tagger) Tag(ctx context.Context, storageUrl, snapshotName, tagName string
 	}
 
 	tagContent := []byte(strings.TrimSuffix(path.Base(attrs.Path), ".json"))
-	tagLocation := fmt.Sprintf("tags/%s", tagName)
+	tagLocation := fmt.Sprintf("tags/%s", args.TagName)
 	reader := bytes.NewReader(tagContent)
 
 	if _, err := store.WriteWithContext(ctx, tagLocation, reader, int64(reader.Len())); err != nil {


### PR DESCRIPTION
To make number of arguments to helper methods more manageable, and maybe start to do something with optional arguments.

Also adds a bazelrc flag. If no bazelrc path is provided, no flag is passed to bazel