### PR TITLE
Refactor cache/grpc client

### DIFF
--- a/snapshots/go/cmd/snapshots/BUILD.bazel
+++ b/snapshots/go/cmd/snapshots/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "utils.go",
     ],
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/cmd/snapshots",
+    visibility = ["//visibility:private"],
     deps = [
         "//snapshots/go/pkg/collecter",
         "//snapshots/go/pkg/differ",

--- a/snapshots/go/cmd/snapshots/collect.go
+++ b/snapshots/go/cmd/snapshots/collect.go
@@ -52,7 +52,7 @@ func newCollectCmd() *collectCmd {
 	cmd.PersistentFlags().StringVar(&cc.workspacePath, "workspace-path", "", "workspace path")
 
 	// collect flags
-	cmd.PersistentFlags().BoolVar(&cc.bazelCacheGrpcInsecure, "bazel-cache-grpc-insecure", false, "use insecure connection for grpc bazel cache")
+	cmd.PersistentFlags().BoolVar(&cc.bazelCacheGrpcInsecure, "bazel_cache_grpc_insecure", false, "use insecure connection for grpc bazel cache")
 	cmd.PersistentFlags().StringArrayVar(&cc.bazelCacheGrpcMetadata, "bazel_cache_grpc_metadata", []string{}, "add metadata to connection for grpc bazel cache")
 	cmd.PersistentFlags().StringVar(&cc.bazelQueryExpression, "bazel-query", "//...", "the bazel query expression to consider")
 	cmd.PersistentFlags().BoolVar(&cc.bazelStderr, "bazel-stderr", false, "show stderr from bazel")

--- a/snapshots/go/cmd/snapshots/diff.go
+++ b/snapshots/go/cmd/snapshots/diff.go
@@ -20,6 +20,7 @@ import (
 
 type diffCmd struct {
 	bazelCacheGrpcInsecure bool
+	bazelCacheGrpcMetadata []string
 	bazelPath              string
 	bazelQueryExpression   string
 	bazelRcPath            string
@@ -62,6 +63,7 @@ names.`,
 
 	// collect flags
 	cmd.PersistentFlags().BoolVar(&dc.bazelCacheGrpcInsecure, "bazel_cache_grpc_insecure", false, "use insecure connection for grpc bazel cache")
+	cmd.PersistentFlags().StringArrayVar(&dc.bazelCacheGrpcMetadata, "bazel_cache_grpc_metadata", []string{}, "add metadata to connection for grpc bazel cache")
 	cmd.PersistentFlags().StringVar(&dc.bazelQueryExpression, "bazel-query", "//...", "the bazel query expression to consider")
 	cmd.PersistentFlags().BoolVar(&dc.bazelStderr, "bazel_stderr", false, "show stderr from bazel")
 	cmd.PersistentFlags().Var(&dc.outputFormat, "format", "output format")
@@ -156,7 +158,8 @@ func (dc *diffCmd) runDiff(cmd *cobra.Command, args []string) error {
 
 	diff := differ.NewDiffer()
 	diffArgs := differ.DiffArgs{
-		BazelCacheGrpcInsecure: dc.bazelCacheGrpcInsecure,
+		BazelCacheGrpcs:        !dc.bazelCacheGrpcInsecure,
+		BazelCacheGrpcMetadata: dc.bazelCacheGrpcMetadata,
 		BazelExpression:        dc.bazelQueryExpression,
 		BazelPath:              dc.bazelPath,
 		BazelRcPath:            dc.bazelRcPath,

--- a/snapshots/go/pkg/bazel/BUILD.bazel
+++ b/snapshots/go/pkg/bazel/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "@org_golang_google_genproto//googleapis/bytestream",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//credentials",
+        "@org_golang_google_grpc//credentials/google",
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//keepalive",
     ],

--- a/snapshots/go/pkg/bazel/BUILD.bazel
+++ b/snapshots/go/pkg/bazel/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "bazel.go",
         "buildevents.go",
         "cache.go",
+        "grpc_client.go",
     ],
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/bazel",
     visibility = ["//visibility:public"],
@@ -13,12 +14,18 @@ go_library(
         "@org_golang_google_genproto//googleapis/bytestream",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//credentials",
+        "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//keepalive",
     ],
 )
 
 go_test(
     name = "bazel_test",
-    srcs = ["cache_test.go"],
+    srcs = [
+        "cache_test.go",
+        "grpc_client_test.go",
+    ],
     data = [
         "cache_test.go",  # the test needs a file to read
     ],

--- a/snapshots/go/pkg/bazel/cache.go
+++ b/snapshots/go/pkg/bazel/cache.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"strings"
 
 	"google.golang.org/genproto/googleapis/bytestream"
 	"google.golang.org/grpc"
@@ -106,7 +107,11 @@ func (c *RemoteBazelCache) Read(ctx context.Context, secure bool, uri string) ([
 		c.clients[u.Host] = client
 	}
 
-	req := &bytestream.ReadRequest{ResourceName: uri}
+	req := &bytestream.ReadRequest{
+		ResourceName: strings.TrimPrefix(u.RequestURI(), "/"), 
+		ReadOffset:   0,
+		ReadLimit:    0,
+	}
 
 	bsrc, err := client.Read(ctx, req)
 	if err != nil {

--- a/snapshots/go/pkg/bazel/cache_test.go
+++ b/snapshots/go/pkg/bazel/cache_test.go
@@ -25,19 +25,19 @@ func TestFileBazelCache(t *testing.T) {
 	var err error
 
 	// invalid scheme
-	contents, err = c.Read(ctx, "no-scheme")
+	contents, err = c.Read(ctx, false, "no-scheme")
 	require.ErrorIs(t, err, ErrScheme)
 	require.Nil(t, contents)
 
 	// wrong scheme
-	contents, err = c.Read(ctx, "http://some-file")
+	contents, err = c.Read(ctx, false, "http://some-file")
 	require.ErrorIs(t, err, ErrScheme)
 	require.Nil(t, contents)
 
 	// read this file
 	thisFile, err := bazeltools.Runfile("snapshots/go/pkg/bazel/cache_test.go")
 	require.Nil(t, err)
-	contents, err = c.Read(ctx, fmt.Sprintf("file://%s", thisFile))
+	contents, err = c.Read(ctx, false, fmt.Sprintf("file://%s", thisFile))
 	require.Nil(t, err)
 	require.Contains(t, string(contents), "literally anything goes here because we're reading this file")
 	require.NotNil(t, contents)
@@ -55,24 +55,24 @@ func TestDelegatingBazelCache(t *testing.T) {
 	var err error
 
 	// invalid scheme
-	contents, err = c.Read(ctx, "no-scheme")
+	contents, err = c.Read(ctx, false, "no-scheme")
 	require.ErrorIs(t, err, ErrScheme)
 	require.Nil(t, contents)
 
 	// wrong scheme
-	contents, err = c.Read(ctx, "wrongscheme://some-uri")
+	contents, err = c.Read(ctx, false, "wrongscheme://some-uri")
 	require.ErrorIs(t, err, ErrScheme)
 	require.Nil(t, contents)
 
 	// file not found
-	contents, err = c.Read(ctx, "file:///doesnt-exist")
+	contents, err = c.Read(ctx, false, "file:///doesnt-exist")
 	require.ErrorIs(t, err, ErrUnavailable)
 	require.Nil(t, contents)
 
 	// delegate to file
 	thisFile, err := bazeltools.Runfile("snapshots/go/pkg/bazel/cache_test.go")
 	require.Nil(t, err)
-	contents, err = c.Read(ctx, fmt.Sprintf("file://%s", thisFile))
+	contents, err = c.Read(ctx, false, fmt.Sprintf("file://%s", thisFile))
 	require.Nil(t, err)
 	require.NotNil(t, contents)
 }
@@ -123,22 +123,22 @@ func TestRemoteBazelCache(t *testing.T) {
 	var err error
 
 	// invalid scheme
-	contents, err = c.Read(ctx, "no-scheme")
+	contents, err = c.Read(ctx, false, "no-scheme")
 	require.ErrorIs(t, err, ErrScheme)
 	require.Nil(t, contents)
 
 	// wrong scheme
-	contents, err = c.Read(ctx, "file://some-file")
+	contents, err = c.Read(ctx, false, "file://some-file")
 	require.ErrorIs(t, err, ErrScheme)
 	require.Nil(t, contents)
 
 	// wrong cache key
-	contents, err = c.Read(ctx, "bytestream://bufnet/wrong-key")
+	contents, err = c.Read(ctx, false, "bytestream://bufnet/wrong-key")
 	require.ErrorIs(t, err, ErrUnavailable)
 	require.Nil(t, contents)
 
 	// good request
-	contents, err = c.Read(ctx, "bytestream://bufnet/cache-key")
+	contents, err = c.Read(ctx, false, "bytestream://bufnet/cache-key")
 	require.Nil(t, err)
 	require.Equal(t, string(contents), "hello world")
 }

--- a/snapshots/go/pkg/bazel/cache_test.go
+++ b/snapshots/go/pkg/bazel/cache_test.go
@@ -82,7 +82,7 @@ type mockByteStreamServer struct {
 }
 
 func (s *mockByteStreamServer) Read(req *bytestream.ReadRequest, stream bytestream.ByteStream_ReadServer) error {
-	if req.GetResourceName() != "bytestream://bufnet/cache-key" {
+	if req.GetResourceName() != "cache-key" {
 		return status.Errorf(codes.NotFound, "wrong cache key: %s", req.GetResourceName())
 	}
 

--- a/snapshots/go/pkg/bazel/grpc_client.go
+++ b/snapshots/go/pkg/bazel/grpc_client.go
@@ -1,0 +1,90 @@
+/* Copyright 2022 Cognite AS */
+
+package bazel
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"math"
+	"net/url"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+)
+
+func DialTarget(target string) (*grpc.ClientConn, error) {
+	return DialTargetWithOptions(target, true)
+}
+
+func DialTargetWithOptions(target string, grpcsBytestream bool, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
+	dialOptions := CommonGRPCClientOptions()
+	dialOptions = append(dialOptions, extraOptions...)
+
+	u, err := url.Parse(target)
+	if err == nil {
+		if u.Scheme != "bytestream" {
+			return nil, fmt.Errorf("expected scheme to be file, not %s: %w", u.Scheme, ErrScheme)
+		}
+
+		if u.User != nil {
+			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(u.User.String())))
+		}
+
+		if grpcsBytestream {
+			cred := credentials.NewTLS(&tls.Config{
+				InsecureSkipVerify: true,
+			})
+			dialOptions = append(dialOptions, grpc.WithTransportCredentials(cred))
+		} else {
+			dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		}
+
+		target = u.Host
+	}
+
+	// Connect to host/port and create a new client
+	return grpc.Dial(target, dialOptions...)
+}
+
+type rpcCredentials struct {
+	authorization string
+}
+
+func newRPCCredentials(authorization string) *rpcCredentials {
+	return &rpcCredentials{
+		authorization: authorization,
+	}
+}
+
+func (c *rpcCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	return map[string]string{
+		"authorization": c.authorization,
+	}, nil
+}
+
+func (c *rpcCredentials) RequireTransportSecurity() bool {
+	return false
+}
+
+func CommonGRPCClientOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			// After a duration of this time if the client doesn't see any activity it
+			// pings the server to see if the transport is still alive.
+			Time: 30 * time.Second,
+
+			// After having pinged for keepalive check, the client waits for a duration
+			// of Timeout and if no activity is seen even after that the connection is
+			// closed.
+			Timeout: 20 * time.Second,
+
+			// If true, client sends keepalive pings even with no active RPCs.
+			PermitWithoutStream: true,
+		}),
+	}
+}

--- a/snapshots/go/pkg/bazel/grpc_client.go
+++ b/snapshots/go/pkg/bazel/grpc_client.go
@@ -4,14 +4,13 @@ package bazel
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"math"
 	"net/url"
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/google"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 )
@@ -35,10 +34,7 @@ func DialTargetWithOptions(target string, grpcsBytestream bool, extraOptions ...
 		}
 
 		if grpcsBytestream {
-			cred := credentials.NewTLS(&tls.Config{
-				InsecureSkipVerify: true,
-			})
-			dialOptions = append(dialOptions, grpc.WithTransportCredentials(cred))
+			dialOptions = append(dialOptions, grpc.WithTransportCredentials(google.NewDefaultCredentials().TransportCredentials()))
 		} else {
 			dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		}

--- a/snapshots/go/pkg/bazel/grpc_client_test.go
+++ b/snapshots/go/pkg/bazel/grpc_client_test.go
@@ -1,0 +1,25 @@
+/* Copyright 2022 Cognite AS */
+
+package bazel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestDialTargetWithOptions(t *testing.T) {
+	var conn *grpc.ClientConn
+	var err error
+
+	// illegal scheme
+	conn, err = DialTargetWithOptions("wrongscheme://some-uri", false)
+	require.ErrorIs(t, err, ErrScheme)
+	require.Nil(t, conn)
+
+	// legal scheme
+	conn, err = DialTargetWithOptions("bytestream://some-uri", false)
+	require.Nil(t, err)
+	require.NotNil(t, conn)
+}

--- a/snapshots/go/pkg/collecter/BUILD.bazel
+++ b/snapshots/go/pkg/collecter/BUILD.bazel
@@ -8,6 +8,6 @@ go_library(
     deps = [
         "//snapshots/go/pkg/bazel",
         "//snapshots/go/pkg/models",
-        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//metadata",
     ],
 )

--- a/snapshots/go/pkg/differ/differ.go
+++ b/snapshots/go/pkg/differ/differ.go
@@ -21,7 +21,8 @@ func NewDiffer() *differ {
 }
 
 type DiffArgs struct {
-	BazelCacheGrpcInsecure bool
+	BazelCacheGrpcs        bool
+	BazelCacheGrpcMetadata []string
 	BazelExpression        string
 	BazelPath              string
 	BazelRcPath            string
@@ -37,7 +38,8 @@ func (*differ) Diff(args *DiffArgs) ([]models.TrackerChange, error) {
 	// if toSnapshot is not set, then run collect
 	if args.ToSnapshot == nil {
 		collectArgs := collecter.CollectArgs{
-			BazelCacheGrpcInsecure: args.BazelCacheGrpcInsecure,
+			BazelCacheGrpcs:        args.BazelCacheGrpcs,
+			BazelCacheGrpcMetadata: args.BazelCacheGrpcMetadata,
 			BazelExpression:        args.BazelExpression,
 			BazelPath:              args.BazelPath,
 			BazelRcPath:            args.BazelRcPath,


### PR DESCRIPTION
Adds a flag to collect and diff that makes it possible to pass metadata (i.e. headers) to the Bazel cache gRPC client.
Refactors cache by moving gRPC client logic.

Still having some issues with reading from cache after remote execution. Getting NotFound errors when trying to pull from the BuildBuddy cache. However, we're successfully connecting to the cache now, and our existing (non-remote execution, but with remote cache) workflow still works as before, so I think this is still an improvement, as the gRPC code is cleaner than before.