### PR TITLE
Use manifest_digest for tracking docker images

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -629,6 +629,10 @@ def go_dependencies():
     )
     go_repository(
         name = "com_google_cloud_go_storage",
+        build_directives = [
+            # fixes `no such package '@com_google_cloud_go_compute_metadata//'`
+            "gazelle:resolve go cloud.google.com/go/compute/metadata @com_google_cloud_go_compute//metadata:go_default_library",  # keep
+        ],
         build_external = "external",
         build_file_proto_mode = "disable_global",
         importpath = "cloud.google.com/go/storage",
@@ -739,6 +743,10 @@ def go_dependencies():
     )
     go_repository(
         name = "org_golang_google_api",
+        build_directives = [
+            # fixes `no such package '@com_google_cloud_go_compute_metadata//'`
+            "gazelle:resolve go cloud.google.com/go/compute/metadata @com_google_cloud_go_compute//metadata:go_default_library",  # keep
+        ],
         build_external = "external",
         build_file_proto_mode = "disable_global",
         importpath = "google.golang.org/api",
@@ -842,6 +850,10 @@ def go_dependencies():
     )
     go_repository(
         name = "org_golang_x_oauth2",
+        build_directives = [
+            # fixes `no such package '@com_google_cloud_go_compute_metadata//'`
+            "gazelle:resolve go cloud.google.com/go/compute/metadata @com_google_cloud_go_compute//metadata:go_default_library",  # keep
+        ],
         build_external = "external",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/oauth2",

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -41,7 +41,10 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
         # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
         for _, data in bundle_info.container_images.items():
             print(data["manifest_digest"])
-            inputs.append(data["manifest_digest"])
+            if data["manifest_digest"] is not None:
+                inputs.append(data["manifest_digest"])
+            else:
+                print("wtf" + data)
 
     args.add_all(inputs)
 

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -44,7 +44,7 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
             if data["manifest_digest"] != None:
                 inputs.append(data["manifest_digest"])
             else:
-                print("wtf" + data)
+                print("wtf" + str(data))
 
     args.add_all(inputs)
 

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -71,7 +71,7 @@ def _change_tracker_impl(ctx):
             # When passing a container_image as a dependency, use the Docker manifest digest
             # for tracking
             # images that come from container_pull without passing them through container_image
-            # do not have the manifest_digets field. Fallback to blobsum in that case.
+            # do not have the manifest_digest field. Fallback to blobsum in that case.
             container_parts = dep[ImageInfo].container_parts
             if container_parts["manifest_digest"] != None:
                 track_files.append(container_parts["manifest_digest"])

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -45,7 +45,7 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
             if data["manifest_digest"] != None:
                 inputs.append(data["manifest_digest"])
             else:
-                inputs.append(data["blobsum"])
+                inputs.extend(data["blobsum"])
 
     args.add_all(inputs)
 
@@ -76,7 +76,7 @@ def _change_tracker_impl(ctx):
             if container_parts["manifest_digest"] != None:
                 track_files.append(container_parts["manifest_digest"])
             else:
-                track_files.append(container_parts["blobsum"])
+                track_files.extend(container_parts["blobsum"])
         else:
             # Handle other targets by just adding all the files
             track_files.extend(dep.files.to_list())

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -39,6 +39,7 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
         # Simplified handling for image bundles: use only the digests of the Docker manifest files.
         # We tried with `blobsum` previous to `manifest_digest`,
         # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
+        print(data.keys())
         for _, data in bundle_info.container_images.items():
             inputs.append(data["manifest"])
 

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -41,7 +41,7 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
         # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
         for _, data in bundle_info.container_images.items():
             print(data["manifest_digest"])
-            if data["manifest_digest"] is not None:
+            if data["manifest_digest"] != None:
                 inputs.append(data["manifest_digest"])
             else:
                 print("wtf" + data)

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -40,7 +40,7 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
         # We tried with `blobsum` previous to `manifest_digest`,
         # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
         for _, data in bundle_info.container_images.items():
-            inputs.append(data["manifest_digest"])
+            inputs.append(data["manifest"])
 
     args.add_all(inputs)
 

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -36,10 +36,11 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
     args.add_all(tags, format_each = "--tag=%s")
 
     for bundle_info in bundle_infos:
-        # Simplified handling for image bundles: use only the blobsum files.
-        # for images created with container_run_and_commit the blobsum doesn't seem to change, so this doesn't work
+        # Simplified handling for image bundles: use only the digests of the Docker manifest files.
+        # We tried with `blobsum` previous to `manifest_digest`,
+        # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
         for _, data in bundle_info.container_images.items():
-            inputs.extend(data["blobsum"])
+            inputs.extend(data["manifest_digest"])
 
     args.add_all(inputs)
 
@@ -62,9 +63,9 @@ def _change_tracker_impl(ctx):
             # Handle BundleInfos separately
             bundle_infos.append(dep[BundleInfo])
         elif ImageInfo in dep:
-            # When passing a container_image as a dependency, use the blobsum
-            # files for tracking
-            track_files.extend(dep[ImageInfo].container_parts["blobsum"])
+            # When passing a container_image as a dependency, use the Docker manifest digest
+            # for tracking
+            track_files.extend(dep[ImageInfo].container_parts["manifest_digest"])
         else:
             # Handle other targets by just adding all the files
             track_files.extend(dep.files.to_list())

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -41,7 +41,7 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
         # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
         for _, data in bundle_info.container_images.items():
             # images that come from container_pull without passing them through container_image
-            # do not have the manifest_digets field. Fallback to blobsum in that case.
+            # do not have the manifest_digest field. Fallback to blobsum in that case.
             if data["manifest_digest"] != None:
                 inputs.append(data["manifest_digest"])
             else:

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -39,8 +39,8 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
         # Simplified handling for image bundles: use only the digests of the Docker manifest files.
         # We tried with `blobsum` previous to `manifest_digest`,
         # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
-        print(data.keys())
         for _, data in bundle_info.container_images.items():
+            print(data.keys())
             inputs.append(data["manifest"])
 
     args.add_all(inputs)

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -41,7 +41,7 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
         # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
         for _, data in bundle_info.container_images.items():
             print(data["manifest_digest"])
-            inputs.append(data["manifest"])
+            inputs.append(data["manifest_digest"])
 
     args.add_all(inputs)
 
@@ -66,7 +66,7 @@ def _change_tracker_impl(ctx):
         elif ImageInfo in dep:
             # When passing a container_image as a dependency, use the Docker manifest digest
             # for tracking
-            track_files.extend(dep[ImageInfo].container_parts["manifest_digest"])
+            track_files.append(dep[ImageInfo].container_parts["manifest_digest"])
         else:
             # Handle other targets by just adding all the files
             track_files.extend(dep.files.to_list())

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -40,7 +40,7 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
         # We tried with `blobsum` previous to `manifest_digest`,
         # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
         for _, data in bundle_info.container_images.items():
-            print(data.keys())
+            print(data["manifest_digest"])
             inputs.append(data["manifest"])
 
     args.add_all(inputs)

--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -40,7 +40,7 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], bundle_infos = [], suf
         # We tried with `blobsum` previous to `manifest_digest`,
         # but for images created with container_run_and_commit and install_pkgs the blobsum doesn't seem to change, so this didn't work.
         for _, data in bundle_info.container_images.items():
-            inputs.extend(data["manifest_digest"])
+            inputs.append(data["manifest_digest"])
 
     args.add_all(inputs)
 


### PR DESCRIPTION
We noticed that the blobsum of some images created by some types of rules does not change. Using the manifest digest as the tracker by default fixes this. We fall back to blobsum if manifest digest isn't provided.