### PR TITLE
become compatible with incompatible_disable_starlark_host_transitions

### DIFF
--- a/snapshots/snapshots.bzl
+++ b/snapshots/snapshots.bzl
@@ -7,7 +7,7 @@ SNAPSHOTS_ATTRS = {
     "_snapshots": attr.label(
         executable = True,
         default = Label("@snapshots-bin//:snapshots"),
-        cfg = "host",
+        cfg = "exec",
     ),
 }
 
@@ -145,7 +145,7 @@ _snapshots_runner = rule(
     attrs = {
         "snapshots": attr.label(
             default = "@snapshots-bin//:snapshots",
-            cfg = "host",
+            cfg = "target",
             executable = True,
             allow_single_file = True,
         ),


### PR DESCRIPTION
`--incompatible_disable_starlark_host_transitions` will become default with bazel 7.0
This makes `cfg = "host"` syntax illegal

Thread: https://github.com/bazelbuild/bazel/issues/17032