### PR TITLE
Export bzl file for stardoc support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,6 +22,13 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    strip_prefix = "",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
+)
+
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load(":deps.bzl", "snapshots_deps")

--- a/snapshots/BUILD.bazel
+++ b/snapshots/BUILD.bazel
@@ -1,7 +1,15 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 exports_files(["runner.tmpl.sh"])
 
-# export bzl files for the documentation
-exports_files(
-    glob(["*.bzl"]),
+bzl_library(
+    name = "snapshots_bzl",
+    srcs = [
+      "snapshots.bzl",
+    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_skylib//lib:shell",
+        "@io_bazel_rules_docker//container:container.docs",
+    ],
 )

--- a/snapshots/BUILD.bazel
+++ b/snapshots/BUILD.bazel
@@ -1,1 +1,7 @@
-exports_files(["runner.tmpl.sh", "snapshots.bzl"])
+exports_files(["runner.tmpl.sh"])
+
+# export bzl files for the documentation
+exports_files(
+    glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+)

--- a/snapshots/BUILD.bazel
+++ b/snapshots/BUILD.bazel
@@ -1,1 +1,1 @@
-exports_files(["runner.tmpl.sh"])
+exports_files(["runner.tmpl.sh", "snapshots.bzl"])


### PR DESCRIPTION
Making the file public allows others to generate docs that depend on this file.