### PR TITLE
First stab at supporting a credential helper

### DIFF
--- a/snapshots/go/cmd/snapshots/collect.go
+++ b/snapshots/go/cmd/snapshots/collect.go
@@ -23,6 +23,7 @@ type collectCmd struct {
 	bazelRcPath            string
 	bazelStderr            bool
 	buildEventsPath        string
+	credentialHelper       string
 	outPath                string
 	noPrint                bool
 	workspacePath          string
@@ -58,6 +59,7 @@ func newCollectCmd() *collectCmd {
 	cmd.PersistentFlags().StringVar(&cc.bazelQueryExpression, "bazel-query", "//...", "the bazel query expression to consider")
 	cmd.PersistentFlags().StringVar(&cc.buildEventsPath, "build_event_json_file", "", "a bazel build event json file")
 	cmd.PersistentFlags().BoolVar(&cc.bazelStderr, "bazel-stderr", false, "show stderr from bazel")
+	cmd.PersistentFlags().StringVar(&cc.credentialHelper, "credential_helper", "", "path to a credential helper, relative to workspace-path")
 	cmd.PersistentFlags().StringVar(&cc.outPath, "out-path", "", "output file path")
 	cmd.PersistentFlags().BoolVar(&cc.noPrint, "no-print", false, "don't print if not writing to file")
 
@@ -122,6 +124,7 @@ func (cc *collectCmd) runCollect(cmd *cobra.Command, args []string) error {
 		BazelWorkspacePath:     cc.workspacePath,
 		BazelWriteStderr:       cc.bazelStderr,
 		BazelBuildEventsPath:   cc.buildEventsPath,
+		CredentialHelper:       exec.Cmd{Path: cc.credentialHelper, Dir: cc.workspacePath},
 		OutPath:                cc.outPath,
 		NoPrint:                cc.noPrint,
 	}

--- a/snapshots/go/cmd/snapshots/diff.go
+++ b/snapshots/go/cmd/snapshots/diff.go
@@ -26,6 +26,7 @@ type diffCmd struct {
 	bazelRcPath            string
 	bazelStderr            bool
 	buildEventsPath        string
+	credentialHelper       string
 	outPath                string
 	noPrint                bool
 	workspacePath          string
@@ -68,6 +69,7 @@ names.`,
 	cmd.PersistentFlags().StringVar(&dc.bazelQueryExpression, "bazel-query", "//...", "the bazel query expression to consider")
 	cmd.PersistentFlags().StringVar(&dc.buildEventsPath, "build_event_json_file", "", "a bazel build event json file")
 	cmd.PersistentFlags().BoolVar(&dc.bazelStderr, "bazel_stderr", false, "show stderr from bazel")
+	cmd.PersistentFlags().StringVar(&dc.credentialHelper, "credential_helper", "", "path to a credential helper, relative to workspace-path")
 	cmd.PersistentFlags().Var(&dc.outputFormat, "format", "output format")
 	cmd.PersistentFlags().StringVar(&dc.outPath, "out", "", "output file path")
 	cmd.PersistentFlags().BoolVar(&dc.noPrint, "no-print", false, "don't print if not writing to file")
@@ -168,6 +170,7 @@ func (dc *diffCmd) runDiff(cmd *cobra.Command, args []string) error {
 		BazelWorkspacePath:     dc.workspacePath,
 		BazelWriteStderr:       dc.bazelStderr,
 		BuildEventsPath:        dc.buildEventsPath,
+		CredentialHelper:       exec.Cmd{Path: dc.credentialHelper, Dir: dc.workspacePath},
 		OutPath:                dc.outPath,
 		NoPrint:                dc.noPrint,
 		FromSnapshot:           dc.fromSnapshot,

--- a/snapshots/go/pkg/cache/BUILD.bazel
+++ b/snapshots/go/pkg/cache/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "cache",
     srcs = [
         "cache.go",
+        "credential_helper.go",
         "grpc_client.go",
     ],
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/cache",

--- a/snapshots/go/pkg/cache/credential_helper.go
+++ b/snapshots/go/pkg/cache/credential_helper.go
@@ -1,0 +1,42 @@
+/* Copyright 2022 Cognite AS */
+
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+type CredentialHelper struct {
+	Cmd *exec.Cmd
+}
+
+type Credentials struct {
+	Headers struct {
+		Authorization []string `json:"Authorization"`
+	} `json:"headers"`
+}
+
+func NewCredentialHelper(cmd *exec.Cmd) *CredentialHelper {
+	return &CredentialHelper{Cmd: cmd}
+}
+
+func (ch *CredentialHelper) GetAuthorization() ([]string, error) {
+	// Having no credential helper isn't an error
+	if ch.Cmd == nil {
+		return nil, nil
+	}
+
+	headers, err := ch.Cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	credentials := &Credentials{}
+	if err := json.Unmarshal(headers, &credentials); err != nil {
+		return nil, fmt.Errorf("invalid headers %s: %w", headers, err)
+	}
+
+	return credentials.Headers.Authorization, nil
+}

--- a/snapshots/go/pkg/cache/grpc_client.go
+++ b/snapshots/go/pkg/cache/grpc_client.go
@@ -15,11 +15,11 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-func DialTarget(target string) (*grpc.ClientConn, error) {
-	return DialTargetWithOptions(target, true)
+func DialTarget(target string, credentialHelper *CredentialHelper) (*grpc.ClientConn, error) {
+	return DialTargetWithOptions(target, true, credentialHelper)
 }
 
-func DialTargetWithOptions(target string, grpcsBytestream bool, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
+func DialTargetWithOptions(target string, grpcsBytestream bool, credentialHelper *CredentialHelper, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 	dialOptions := CommonGRPCClientOptions()
 	dialOptions = append(dialOptions, extraOptions...)
 
@@ -29,7 +29,15 @@ func DialTargetWithOptions(target string, grpcsBytestream bool, extraOptions ...
 			return nil, fmt.Errorf("expected scheme to be file, not %s: %w", u.Scheme, ErrScheme)
 		}
 
-		if u.User != nil {
+		// Only get user credentials if no credential helper is provided
+		if credentialHelper != nil {
+			credentials, err := credentialHelper.GetAuthorization()
+			if err != nil {
+				return nil, err
+			}
+
+			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(credentials[0])))
+		} else if u.User != nil {
 			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(u.User.String())))
 		}
 

--- a/snapshots/go/pkg/cache/grpc_client_test.go
+++ b/snapshots/go/pkg/cache/grpc_client_test.go
@@ -14,12 +14,12 @@ func TestDialTargetWithOptions(t *testing.T) {
 	var err error
 
 	// illegal scheme
-	conn, err = DialTargetWithOptions("wrongscheme://some-uri", false)
+	conn, err = DialTargetWithOptions("wrongscheme://some-uri", false, nil)
 	require.ErrorIs(t, err, ErrScheme)
 	require.Nil(t, conn)
 
 	// legal scheme
-	conn, err = DialTargetWithOptions("bytestream://some-uri", false)
+	conn, err = DialTargetWithOptions("bytestream://some-uri", false, nil)
 	require.Nil(t, err)
 	require.NotNil(t, conn)
 }

--- a/snapshots/go/pkg/collecter/collecter.go
+++ b/snapshots/go/pkg/collecter/collecter.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 
 	"google.golang.org/grpc/metadata"
@@ -33,6 +34,7 @@ type CollectArgs struct {
 	BazelWorkspacePath     string
 	BazelWriteStderr       bool
 	BazelBuildEventsPath   string
+	CredentialHelper       exec.Cmd
 	OutPath                string
 	NoPrint                bool
 }
@@ -50,7 +52,7 @@ func (c *collecter) Collect(args *CollectArgs) (*models.Snapshot, error) {
 
 	var buildEvents []bazel.BuildEventOutput
 	ctx := context.Background()
-	bcache := cache.NewDefaultDelegatingCache()
+	bcache := cache.NewDefaultDelegatingCache(&args.CredentialHelper)
 
 	// build digests, get the build events
 	log.Printf("collecting digests from %s", args.BazelExpression)

--- a/snapshots/go/pkg/differ/differ.go
+++ b/snapshots/go/pkg/differ/differ.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os/exec"
 	"sort"
 	"strings"
 
@@ -29,6 +30,7 @@ type DiffArgs struct {
 	BazelWorkspacePath     string
 	BazelWriteStderr       bool
 	BuildEventsPath        string
+	CredentialHelper       exec.Cmd
 	OutPath                string
 	NoPrint                bool
 	FromSnapshot           *models.Snapshot
@@ -47,6 +49,7 @@ func (*differ) Diff(args *DiffArgs) ([]models.TrackerChange, error) {
 			BazelWorkspacePath:     args.BazelWorkspacePath,
 			BazelWriteStderr:       args.BazelWriteStderr,
 			BazelBuildEventsPath:   args.BuildEventsPath,
+			CredentialHelper:       args.CredentialHelper,
 			OutPath:                args.OutPath,
 			NoPrint:                args.NoPrint,
 		}


### PR DESCRIPTION
Bazel has added a `--credential-helper=<pattern>=<path>` flag, where the credential helper at `<path>` will be called before connecting to a remote address matching `<pattern>`. This isn't quite that fancy, but lets users pass a single credential helper which will be used for all paths, and gives us a starting point to iterate.

The helper returns a json structure containing headers which are passed along when we connect to a remote cache, in the exact same format as the helpers passed to bazel, allowing us to use the same helper in both places.

The design doc for credential helpers in bazel provides useful background: https://github.com/bazelbuild/proposals/blob/main/designs/2022-06-07-bazel-credential-helpers.md