### PR TITLE
Verify that credential helper path is non-empty before invoking

### DIFF
--- a/snapshots/go/cmd/snapshots/collect.go
+++ b/snapshots/go/cmd/snapshots/collect.go
@@ -124,7 +124,7 @@ func (cc *collectCmd) runCollect(cmd *cobra.Command, args []string) error {
 		BazelWorkspacePath:     cc.workspacePath,
 		BazelWriteStderr:       cc.bazelStderr,
 		BazelBuildEventsPath:   cc.buildEventsPath,
-		CredentialHelper:       exec.Cmd{Path: cc.credentialHelper, Dir: cc.workspacePath},
+		CredentialHelper:       cc.credentialHelper,
 		OutPath:                cc.outPath,
 		NoPrint:                cc.noPrint,
 	}

--- a/snapshots/go/cmd/snapshots/diff.go
+++ b/snapshots/go/cmd/snapshots/diff.go
@@ -170,7 +170,7 @@ func (dc *diffCmd) runDiff(cmd *cobra.Command, args []string) error {
 		BazelWorkspacePath:     dc.workspacePath,
 		BazelWriteStderr:       dc.bazelStderr,
 		BuildEventsPath:        dc.buildEventsPath,
-		CredentialHelper:       exec.Cmd{Path: dc.credentialHelper, Dir: dc.workspacePath},
+		CredentialHelper:       dc.credentialHelper,
 		OutPath:                dc.outPath,
 		NoPrint:                dc.noPrint,
 		FromSnapshot:           dc.fromSnapshot,

--- a/snapshots/go/pkg/cache/BUILD.bazel
+++ b/snapshots/go/pkg/cache/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "cache",
     srcs = [
         "cache.go",
-        "credential_helper.go",
         "grpc_client.go",
     ],
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/cache",

--- a/snapshots/go/pkg/cache/cache.go
+++ b/snapshots/go/pkg/cache/cache.go
@@ -36,14 +36,14 @@ type DelegatingBazelCache struct {
 	caches map[string]BazelCache
 }
 
-func NewDefaultDelegatingCache(credentialHelper *exec.Cmd, dialOptions ...grpc.DialOption) BazelCache {
+func NewDefaultDelegatingCache(credentials string, dialOptions ...grpc.DialOption) BazelCache {
 	return &DelegatingBazelCache{
 		caches: map[string]BazelCache{
 			"file": &FileBazelCache{},
 			"bytestream": &RemoteBazelCache{
-				clients:          make(map[string]bytestream.ByteStreamClient),
-				credentialHelper: NewCredentialHelper(credentialHelper),
-				DialOptions:      dialOptions,
+				clients:     make(map[string]bytestream.ByteStreamClient),
+				credentials: credentials,
+				DialOptions: dialOptions,
 			},
 		},
 	}
@@ -88,9 +88,9 @@ func (c *FileBazelCache) Read(ctx context.Context, secure bool, uri string) ([]b
 
 // RemoteBazelCache provides access to cached items with 'bytestream://' uris.
 type RemoteBazelCache struct {
-	clients          map[string]bytestream.ByteStreamClient
-	credentialHelper *CredentialHelper
-	DialOptions      []grpc.DialOption
+	clients     map[string]bytestream.ByteStreamClient
+	credentials string
+	DialOptions []grpc.DialOption
 }
 
 func (c *RemoteBazelCache) Read(ctx context.Context, secure bool, uri string) ([]byte, error) {
@@ -102,7 +102,7 @@ func (c *RemoteBazelCache) Read(ctx context.Context, secure bool, uri string) ([
 	// obtain a client
 	client, ok := c.clients[u.Host]
 	if !ok {
-		conn, err := DialTargetWithOptions(uri, secure, c.credentialHelper, c.DialOptions...)
+		conn, err := DialTargetWithOptions(uri, secure, c.credentials, c.DialOptions...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to dial host %s: %w", u.Host, err)
 		}

--- a/snapshots/go/pkg/cache/cache.go
+++ b/snapshots/go/pkg/cache/cache.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"os/exec"
 	"strings"
 
 	"google.golang.org/genproto/googleapis/bytestream"

--- a/snapshots/go/pkg/cache/credential_helper.go
+++ b/snapshots/go/pkg/cache/credential_helper.go
@@ -24,7 +24,7 @@ func NewCredentialHelper(cmd *exec.Cmd) *CredentialHelper {
 
 func (ch *CredentialHelper) GetAuthorization() ([]string, error) {
 	// Having no credential helper isn't an error
-	if ch.Cmd == nil {
+	if ch.Cmd == nil || ch.Cmd.Path == "" {
 		return nil, nil
 	}
 

--- a/snapshots/go/pkg/cache/grpc_client.go
+++ b/snapshots/go/pkg/cache/grpc_client.go
@@ -36,7 +36,9 @@ func DialTargetWithOptions(target string, grpcsBytestream bool, credentialHelper
 				return nil, err
 			}
 
-			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(credentials[0])))
+			if len(credentials) > 0 {
+				dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(credentials[0])))
+			}
 		} else if u.User != nil {
 			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(u.User.String())))
 		}

--- a/snapshots/go/pkg/cache/grpc_client.go
+++ b/snapshots/go/pkg/cache/grpc_client.go
@@ -15,11 +15,11 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-func DialTarget(target string, credentialHelper *CredentialHelper) (*grpc.ClientConn, error) {
-	return DialTargetWithOptions(target, true, credentialHelper)
+func DialTarget(target string, credentials string) (*grpc.ClientConn, error) {
+	return DialTargetWithOptions(target, true, credentials)
 }
 
-func DialTargetWithOptions(target string, grpcsBytestream bool, credentialHelper *CredentialHelper, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
+func DialTargetWithOptions(target string, grpcsBytestream bool, credentials string, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 	dialOptions := CommonGRPCClientOptions()
 	dialOptions = append(dialOptions, extraOptions...)
 
@@ -30,15 +30,8 @@ func DialTargetWithOptions(target string, grpcsBytestream bool, credentialHelper
 		}
 
 		// Only get user credentials if no credential helper is provided
-		if credentialHelper != nil {
-			credentials, err := credentialHelper.GetAuthorization()
-			if err != nil {
-				return nil, err
-			}
-
-			if len(credentials) > 0 {
-				dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(credentials[0])))
-			}
+		if len(credentials) != 0 {
+			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(credentials)))
 		} else if u.User != nil {
 			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(u.User.String())))
 		}

--- a/snapshots/go/pkg/cache/grpc_client_test.go
+++ b/snapshots/go/pkg/cache/grpc_client_test.go
@@ -14,12 +14,12 @@ func TestDialTargetWithOptions(t *testing.T) {
 	var err error
 
 	// illegal scheme
-	conn, err = DialTargetWithOptions("wrongscheme://some-uri", false, nil)
+	conn, err = DialTargetWithOptions("wrongscheme://some-uri", false, "")
 	require.ErrorIs(t, err, ErrScheme)
 	require.Nil(t, conn)
 
 	// legal scheme
-	conn, err = DialTargetWithOptions("bytestream://some-uri", false, nil)
+	conn, err = DialTargetWithOptions("bytestream://some-uri", false, "")
 	require.Nil(t, err)
 	require.NotNil(t, conn)
 }

--- a/snapshots/go/pkg/collecter/BUILD.bazel
+++ b/snapshots/go/pkg/collecter/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "collecter",
-    srcs = ["collecter.go"],
+    srcs = [
+        "collecter.go",
+        "credential_helper.go",
+    ],
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/collecter",
     visibility = ["//visibility:public"],
     deps = [

--- a/snapshots/go/pkg/differ/differ.go
+++ b/snapshots/go/pkg/differ/differ.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os/exec"
 	"sort"
 	"strings"
 
@@ -30,7 +29,7 @@ type DiffArgs struct {
 	BazelWorkspacePath     string
 	BazelWriteStderr       bool
 	BuildEventsPath        string
-	CredentialHelper       exec.Cmd
+	CredentialHelper       string
 	OutPath                string
 	NoPrint                bool
 	FromSnapshot           *models.Snapshot


### PR DESCRIPTION
Saw crashes without this check. We should probably improve our test coverage.