### PR TITLE
Use rules_go go_deps to import go dependencies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,4 +2,6 @@
 build --verbose_failures
 test --test_output=errors
 
+common --enable_bzlmod
+
 try-import %workspace%/user.bazelrc

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,12 +12,12 @@ go_deps.from_file(go_mod = "//:go.mod")
 
 use_repo(
     go_deps,
-    "org_golang_google_genproto_googleapis_bytestream",
     "com_github_olekukonko_tablewriter",
     "com_github_spf13_cobra",
     "com_github_stretchr_testify",
     "io_beyondstorage_go_services_gcs_v3",
     "io_beyondstorage_go_v5",
+    "org_golang_google_genproto_googleapis_bytestream",
     "org_golang_google_grpc",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,23 +3,30 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "gazelle", version = "0.32.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.33.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
+bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+
+use_repo(
+    go_deps,
+    "org_golang_google_genproto_googleapis_bytestream",
+    "com_github_olekukonko_tablewriter",
+    "com_github_spf13_cobra",
+    "com_github_stretchr_testify",
+    "io_beyondstorage_go_services_gcs_v3",
+    "io_beyondstorage_go_v5",
+    "org_golang_google_grpc",
+)
+
 snapshots = use_extension("@com_cognitedata_bazel_snapshots//snapshots:extensions.bzl", "snapshots")
 snapshots.toolchains(from_source = True)
 
 use_repo(
     snapshots,
     "snapshots_snaptool_toolchains",
-    "com_github_olekukonko_tablewriter",
-    "com_github_spf13_cobra",
-    "com_github_stretchr_testify",
-    "io_beyondstorage_go_services_gcs_v3",
-    "io_beyondstorage_go_v5",
-    "org_golang_google_genproto",
-    "org_golang_google_genproto_googleapis_bytestream",
-    "org_golang_google_grpc",
 )
 
 register_toolchains("@snapshots_snaptool_toolchains//:all")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "com_cognitedata_bazel_snapshots",
-    version = "0.0.0",
+    version = "0.8.0",
 )
 
 bazel_dep(name = "gazelle", version = "0.33.0", repo_name = "bazel_gazelle")


### PR DESCRIPTION
This ensures that dependencies that we import are available downstream