### PR TITLE
Set version in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "com_cognitedata_bazel_snapshots",
-    version = "0.9.0",
+    version = "0.9.1",
 )
 
 bazel_dep(name = "gazelle", version = "0.34.0", repo_name = "bazel_gazelle")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "com_cognitedata_bazel_snapshots",
-    version = "0.8.0",
+    version = "0.9.0",
 )
 
 bazel_dep(name = "gazelle", version = "0.34.0", repo_name = "bazel_gazelle")


### PR DESCRIPTION
This seems very annoying, but let's just do it for now.

Should help getting rid of
```
DEBUG: /bazel-cache/infrastructure/external/gazelle~0.34.0/internal/bzlmod/go_deps.bzl:349:40: Go module "github.com/cognitedata/bazel-snapshots" is provided by Bazel module "com_cognitedata_bazel_snapshots" in version 0.8.0, but requested at higher version 0.9.0 via Go requirements. Consider adding or updating an appropriate "bazel_dep" to ensure that the Bazel module is used to provide the Go module.
```