### PR TITLE
Do not load go_dependencies() in bzlmod extension

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ use_repo(
     "org_golang_google_grpc",
 )
 
-snapshots = use_extension("@com_cognitedata_bazel_snapshots//snapshots:extensions.bzl", "snapshots")
+snapshots = use_extension("//snapshots:extensions.bzl", "snapshots")
 snapshots.toolchains(from_source = True)
 
 use_repo(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,6 @@ bazel_dep(name = "rules_go", version = "0.47.1", repo_name = "io_bazel_rules_go"
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
-
 use_repo(
     go_deps,
     "com_github_olekukonko_tablewriter",
@@ -23,7 +22,6 @@ use_repo(
 
 snapshots = use_extension("//snapshots:extensions.bzl", "snapshots")
 snapshots.toolchains(from_source = True)
-
 use_repo(
     snapshots,
     "snapshots_snaptool_toolchains",

--- a/snapshots/extensions.bzl
+++ b/snapshots/extensions.bzl
@@ -1,4 +1,3 @@
-load("@com_cognitedata_bazel_snapshots//snapshots:dependencies.bzl", "go_dependencies")
 load("@com_cognitedata_bazel_snapshots//snapshots:repositories.bzl", "snapshots_register_toolchains")
 
 toolchains = tag_class(attrs = {
@@ -17,8 +16,6 @@ toolchains = tag_class(attrs = {
 
 # buildifier: disable=unused-variable
 def _snapshots_extension(module_ctx):
-    go_dependencies()
-
     registrations = {}
     for mod in module_ctx.modules:
         for toolchains in mod.tags.toolchains:


### PR DESCRIPTION
All direct dependencies are already loaded through go.mod in MODULE.bazel. As such it is not needed, or desired, to also load the legacy go_dependencies() macro in our bzlmod extension. Furthermore, doing so causes errors for consumers of this module in some situations.