### PR TITLE
README: Fix installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `change_tracker` rule is a stand-alone rule defining a tracker.
 You can use it to create trackers for existing targets.
 
 ```skylark
-load("@com_cognitedata_bazel_snapshots//snapshots:snapshots.bzl", "snapshots", "change_tracker")
+load("@com_cognitedata_bazel_snapshots//snapshots:defs.bzl", "snapshots", "change_tracker")
 
 # A change_tracker
 change_tracker(


### PR DESCRIPTION
The example should refer to defs.bzl, not snapshots.bzl
(there's no public snapshots.bzl).
