### PR TITLE
bazel: Don't buffer build events in memory

### DIFF
--- a/snapshots/go/pkg/bazel/BUILD.bazel
+++ b/snapshots/go/pkg/bazel/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "bazel",
@@ -8,4 +8,14 @@ go_library(
     ],
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/bazel",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "bazel_test",
+    srcs = ["bazel_test.go"],
+    embed = [":bazel"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/snapshots/go/pkg/bazel/bazel_test.go
+++ b/snapshots/go/pkg/bazel/bazel_test.go
@@ -1,0 +1,49 @@
+package bazel
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBuildEventsFile(t *testing.T) {
+	input := `
+{"id": {"targetCompleted":{"label":"//foo:bar"}}}
+{"id": {"targetCompleted":{"label":"//foo:baz"}}}
+{"id": {"targetCompleted":{"label":"//foo:qux"}}}
+`
+	var got []BuildEventOutput
+	for ev, err := range ParseBuildEventsFile(strings.NewReader(input)) {
+		require.NoError(t, err)
+		got = append(got, ev)
+	}
+
+	require.Len(t, got, 3)
+	assert.Equal(t, "//foo:bar", got[0].ID.TargetCompleted.Label)
+	assert.Equal(t, "//foo:baz", got[1].ID.TargetCompleted.Label)
+	assert.Equal(t, "//foo:qux", got[2].ID.TargetCompleted.Label)
+}
+
+func TestParseBuildEventsFile_errors(t *testing.T) {
+	t.Run("invalid JSON", func(t *testing.T) {
+		input := `{"id": {"targetCompleted":`
+		var err error
+		for _, err = range ParseBuildEventsFile(strings.NewReader(input)) {
+		}
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "error parsing build event file")
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		giveErr := errors.New("great sadness")
+		var err error
+		for _, err = range ParseBuildEventsFile(iotest.ErrReader(giveErr)) {
+		}
+		require.Error(t, err)
+		assert.ErrorIs(t, err, giveErr)
+	})
+}


### PR DESCRIPTION
Instead of buffering all build events in memory
stream them with an iterator (new in Go 1.23).

This should reduce memory pressure in really large builds
where there are lots of build events and we only care about a handful.

(Also fixes a leaking file descriptor in Collector.Collect.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cognitedata/bazel-snapshots/280)
<!-- Reviewable:end -->
