### PR TITLE
all: drop use of io/ioutil

### DIFF
--- a/snapshots/go/cmd/snapshots/diff.go
+++ b/snapshots/go/cmd/snapshots/diff.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -85,7 +84,7 @@ func (dc *diffCmd) resolveSnapshot(ctx context.Context, name, storageUrl string)
 	if _, err := os.Stat(name); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to look for file: %w", err)
 	} else if err == nil {
-		fileBytes, err := ioutil.ReadFile(name)
+		fileBytes, err := os.ReadFile(name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file %s: %w", name, err)
 		}

--- a/snapshots/go/cmd/snapshots/push.go
+++ b/snapshots/go/cmd/snapshots/push.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 
 	"github.com/spf13/cobra"
@@ -75,7 +75,7 @@ func (pc *pushCmd) checkArgs(args []string) error {
 
 		log.Println("reading snapshot from", pc.snapshotPath)
 		pc.snapshot = &models.Snapshot{}
-		contents, err := ioutil.ReadFile(pc.snapshotPath)
+		contents, err := os.ReadFile(pc.snapshotPath)
 		if err != nil {
 			return fmt.Errorf("failed to read snapshot path: %w", err)
 		}

--- a/snapshots/go/pkg/cache/cache.go
+++ b/snapshots/go/pkg/cache/cache.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -74,7 +73,7 @@ func (c *FileBazelCache) Read(ctx context.Context, secure bool, uri string) ([]b
 		return nil, fmt.Errorf("expected scheme to be file, not %s: %w", u.Scheme, ErrScheme)
 	}
 
-	contents, err := ioutil.ReadFile(u.Path)
+	contents, err := os.ReadFile(u.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("file %s does not exist: %w", u.Path, ErrUnavailable)

--- a/snapshots/go/pkg/digester/digester.go
+++ b/snapshots/go/pkg/digester/digester.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -58,5 +57,5 @@ func (d *digester) Digest(args *DigestArgs) error {
 		return fmt.Errorf("failed to render json file: %w", err)
 	}
 
-	return ioutil.WriteFile(args.OutPath, content, 0644)
+	return os.WriteFile(args.OutPath, content, 0o644)
 }

--- a/snapshots/go/pkg/getter/getter.go
+++ b/snapshots/go/pkg/getter/getter.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path"
 	"strings"
 
@@ -45,7 +45,7 @@ func (g *getter) Get(ctx context.Context, args *GetArgs) (*models.Snapshot, erro
 			if err != nil {
 				return nil, fmt.Errorf("failed to look for tag %s: %w", args.Name, err)
 			}
-			snapshotBytes, err := ioutil.ReadAll(tagBuffer)
+			snapshotBytes, err := io.ReadAll(tagBuffer)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read tag: %w", err)
 			}


### PR DESCRIPTION
"io/ioutil" has been deprecated since Go 1.19.
Switch to "os" and "io" variants of the same functions.
