### PR TITLE
MODULE.bazel: Use Go version from go.mod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,9 @@ bazel_dep(name = "gazelle", version = "0.44.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "rules_go", version = "0.55.1", repo_name = "io_bazel_rules_go")
 
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.from_file(go_mod = "//:go.mod")
+
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(


### PR DESCRIPTION
Despite documentation for rules_go stating that the module
will use the latest Go version by default ([ref](https://github.com/bazel-contrib/rules_go/blob/master/docs/go/core/bzlmod.md#go-sdks))
that appears to not be the case:

```
❯ bazel run @io_bazel_rules_go//go -- version
# ...
go version go1.23.6 darwin/arm64
```

This change configures it explicitly to use the Go version
specified in the `go.mod` file.

Verification:

```
❯ bazel run @io_bazel_rules_go//go -- version
# ...
go version go1.24.5 darwin/arm64
```
