### PR TITLE
ci/release: Provide subresource integrity snippet

### DIFF
--- a/.github/scripts/import_snippets.sh
+++ b/.github/scripts/import_snippets.sh
@@ -12,7 +12,9 @@ TARFILE="$1"
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}
 VERSION=${TAG//v/}
-SHA=$(shasum -a 256 $TARFILE | awk '{print $1}')
+
+# https://github.com/bazelbuild/bazel/issues/17124
+INTEGRITY=$(openssl dgst -sha256 -binary "$TARFILE" | openssl base64 -A | sed 's/^/sha256-/')
 
 cat << EOF
 Add to your \`MODULE.bazel\` file:
@@ -22,7 +24,7 @@ bazel_dep(name = "com_cognitedata_bazel_snapshots", version = "${VERSION}")
 
 archive_override(
     module_name = "com_cognitedata_bazel_snapshots",
-    sha256 = "${SHA}",
+    integrity = "${INTEGRITY}",
     urls = ["https://github.com/cognitedata/bazel-snapshots/releases/download/${TAG}/snapshots-${TAG}.tar"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,3 +13,10 @@ gazelle(
     command = "update",
     extra_args = ["-mode=diff"],
 )
+
+exports_files(
+    [
+        ".github/scripts/import_snippets.sh",
+    ],
+    visibility = ["//tests:__pkg__"],
+)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [Releases](https://github.com/cognitedata/bazel-snapshots/releases) for the 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "com_cognitedata_bazel_snapshots",
-    sha256 = "...",
+    integrity = "...",
     url = "https://github.com/cognitedata/bazel-snapshots/releases/download/<VERSION>/snapshots-<VERSION>.tar",
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "tests_test",
+    srcs = ["import_snippets_test.go"],
+    data = ["//:.github/scripts/import_snippets.sh"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/tools/bazel",
+    ],
+)

--- a/tests/import_snippets_test.go
+++ b/tests/import_snippets_test.go
@@ -1,0 +1,53 @@
+package tests
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	bazeltools "github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var integrityHashRe = regexp.MustCompile(`integrity = "(sha256-[a-zA-Z0-9+/=]+)"`)
+
+func TestImportSnippets(t *testing.T) {
+	const dummyContents = "dummy archive content"
+
+	archive := filepath.Join(t.TempDir(), "snippets.tar.gz")
+	require.NoError(t, os.WriteFile(archive, []byte(dummyContents), 0o644))
+
+	script, err := bazeltools.Runfile(".github/scripts/import_snippets.sh")
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	defer func() {
+		// Surface stderr for debugging if the test fails.
+		if t.Failed() {
+			t.Logf("stderr:\n%s", stderr.String())
+		}
+	}()
+
+	cmd := exec.Command("bash", script, archive)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(), "GITHUB_REF_NAME=v1.2.3")
+	require.NoError(t, cmd.Run())
+	require.Empty(t, stderr.String(), "stderr should be empty")
+
+	// Verify that the integrity hash is valid.
+	matches := integrityHashRe.FindStringSubmatch(stdout.String())
+	require.Len(t, matches, 2, "integrity hash should be found")
+	gotIntegrityHash := matches[1]
+
+	wantSHA := sha256.Sum256([]byte(dummyContents))
+	wantIntegrityHash := "sha256-" + base64.StdEncoding.EncodeToString(wantSHA[:])
+
+	assert.Equal(t, wantIntegrityHash, gotIntegrityHash, "integrity hash should match expected value")
+}


### PR DESCRIPTION
In the import snippet for published releases,
generate an SRI hash instead of a SHA256 hash.
Snippet for generating the SRI hash copied from
https://github.com/bazelbuild/bazel/issues/17124.

Resolves #240
