### PR TITLE
fix(runner.tmpl.sh): allow -h when snapshot-url is specified

### DIFF
--- a/snapshots/private/runner.tmpl.sh
+++ b/snapshots/private/runner.tmpl.sh
@@ -6,10 +6,14 @@ ARGS=@@ARGS@@
 SNAPSHOTS=@@SNAPSHOTS@@
 
 # args should go after the command to run
-COMMAND="${1-}"
+COMMAND=
+if [[ $# -gt 0 && "$1" != -* ]]; then
+    # If the first argument is not an option, treat it as the command
+    COMMAND="$1"
+    shift
+fi
 
 if [ $# -ne 0 ]; then
-    shift
     ARGS+=("$@")
 fi
 


### PR DESCRIPTION
If a snapshot_url is specified in the configuration,
`bazel run //:snapshots -- --help/-h` stop working.

```
❯ bazel run //:snapshots -- -h
INFO: Analyzed target //:snapshots (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:snapshots up-to-date:
  bazel-bin/snapshots-runner.bash
  bazel-bin/snapshots
INFO: Elapsed time: 0.118s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/snapshots <args omitted>
Error: unknown command "s3://my-bucket/my-workspace" for "snapshots"
Run 'snapshots --help' for usage.
snapshots: unknown command "s3://my-bucket/my-workspace" for "snapshots"
```

This fixes the issue by treating the first argument as a command
only if it does not start with a dash (`-`).

Verified locally with a `local_path_override`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cognitedata/bazel-snapshots/292)
<!-- Reviewable:end -->
