### PR TITLE
chore(diff): improve -h output

### DIFF
--- a/snapshots/go/cmd/snapshots/diff.go
+++ b/snapshots/go/cmd/snapshots/diff.go
@@ -43,11 +43,11 @@ type diffCmd struct {
 
 func newDiffCmd() *diffCmd {
 	cmd := &cobra.Command{
-		Use:   "diff",
+		Use:   "diff --format=FORMAT FROM [TO]",
 		Short: "Diff snapshots",
-		Long: `Compiles a list of the labels which have had changes between two snapshots,
+		Long: `Compiles a list of the labels which have had changes between two snapshots (FROM and TO),
 together with what type of change has been made: added, removed or changed.
-If only one snapshot is given, then the "to"-snapshot is created from the
+If only the FROM snapshot is given, then the TO snapshot is created from the
 current state (see collect). Snapshots can either be files, tags or snapshot
 names.`,
 		Args: cobra.RangeArgs(1, 2),


### PR DESCRIPTION
`snapshots diff -h` reports usage as just `diff`,
except the snapshot names and output format are not optional.

This changes the usage to clarify what's required.

Related:
It's strange for format to be required.
We can make it optional if y'all have a preferred default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cognitedata/bazel-snapshots/293)
<!-- Reviewable:end -->
