### PR TITLE
chore(cmd/tag): drop unused flags

### DIFF
--- a/snapshots/go/cmd/snapshots/tag.go
+++ b/snapshots/go/cmd/snapshots/tag.go
@@ -13,14 +13,9 @@ import (
 )
 
 type tagCmd struct {
-	bazelCacheGrpcInsecure bool
-	bazelQueryExpression   string
-	bazelStderr            bool
-	outPath                string
-	noPrint                bool
-	workspacePath          string
-	snapshotName           string
-	tagName                string
+	workspacePath string
+	snapshotName  string
+	tagName       string
 
 	storageUrl string
 
@@ -50,11 +45,6 @@ snapshot which was most recently deployed.
 	cmd.PersistentFlags().StringVar(&cc.workspacePath, "workspace-path", "", "workspace path")
 
 	// tag flags
-	cmd.PersistentFlags().BoolVar(&cc.bazelCacheGrpcInsecure, "bazel-cache-grpc-insecure", true, "use insecure connection for grpc bazel cache")
-	cmd.PersistentFlags().StringVar(&cc.bazelQueryExpression, "bazel-query", "//...", "the bazel query expression to consider")
-	cmd.PersistentFlags().BoolVar(&cc.bazelStderr, "bazel-stderr", false, "show stderr from bazel")
-	cmd.PersistentFlags().StringVar(&cc.outPath, "out-path", "", "output file path")
-	cmd.PersistentFlags().BoolVar(&cc.noPrint, "no-print", false, "don't print if not writing to file")
 	cmd.PersistentFlags().StringVar(&cc.snapshotName, "name", "", "snapshot name")
 
 	cmd.RunE = cc.runTag


### PR DESCRIPTION
A number of flags defined on the tag subcommand are not used.
Delete them.

Before:

```
      --bazel-cache-grpc-insecure   use insecure connection for grpc bazel cache (default true)
      --bazel-query string          the bazel query expression to consider (default "//...")
      --bazel-stderr                show stderr from bazel
  -h, --help                        help for tag
      --name string                 snapshot name
      --no-print                    don't print if not writing to file
      --out-path string             output file path
      --workspace-path string       workspace path
```

Now:

```
  -h, --help                    help for tag
      --name string             snapshot name
      --workspace-path string   workspace path
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cognitedata/bazel-snapshots/295)
<!-- Reviewable:end -->
