### PR TITLE
fix(change_tracker): use depset to de-dupe inputs

### DIFF
--- a/snapshots/private/snapshots.bzl
+++ b/snapshots/private/snapshots.bzl
@@ -39,17 +39,10 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], suffix = ".tracker.jso
     return OutputGroupInfo(change_track_files = depset([tracker_file]))
 
 def _change_tracker_impl(ctx):
-    track_files = []
-    for dep in ctx.attr.deps:
-        track_files.extend(dep.files.to_list())
-
-    # unique track_files
-    track_files = [x for i, x in enumerate(track_files) if i == track_files.index(x)]
-
     return [
         create_tracker_file(
             ctx,
-            track_files,
+            inputs = depset(ctx.files.deps),
             run = [target.label for target in ctx.attr.run],
             tags = ctx.attr.tracker_tags,
             suffix = ".json",


### PR DESCRIPTION
We currently convert the depsets into a list of files
and perform an O(n^2) operation to de-dupe the list.
This is not necessary as depset can take care of this automatically.

This changes the `change_tracker` rule to
build a depset from the full list of files (`ctx.files.deps`)
and pass that depset directly as the `inputs` argument.

The create_tracker_file function does not need to be changed
as `args.add_all` accepts depsets as input as well as lists.
