### PR TITLE
refac(tagger): decouple from storage implementation

### DIFF
--- a/snapshots/go/cmd/snapshots/BUILD.bazel
+++ b/snapshots/go/cmd/snapshots/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//snapshots/go/pkg/getter",
         "//snapshots/go/pkg/models",
         "//snapshots/go/pkg/pusher",
+        "//snapshots/go/pkg/storage",
         "//snapshots/go/pkg/tagger",
         "@com_github_spf13_cobra//:cobra",
     ],

--- a/snapshots/go/cmd/snapshots/tag.go
+++ b/snapshots/go/cmd/snapshots/tag.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
 	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/tagger"
 )
 
@@ -85,12 +86,16 @@ func (tc *tagCmd) runTag(cmd *cobra.Command, args []string) error {
 	log.Printf("snapshot:  %s", tc.snapshotName)
 	log.Printf("tag:       %s", tc.tagName)
 
+	store, err := storage.NewStorage(tc.storageURL)
+	if err != nil {
+		return fmt.Errorf("open storage client: %w", err)
+	}
+
 	tagArgs := tagger.TagArgs{
 		SnapshotName: tc.snapshotName,
-		StorageUrl:   tc.storageURL,
 		TagName:      tc.tagName,
 	}
-	obj, err := tagger.NewTagger().Tag(ctx, &tagArgs)
+	obj, err := tagger.NewTagger(store).Tag(ctx, &tagArgs)
 	if err != nil {
 		return err
 	}

--- a/snapshots/go/pkg/tagger/BUILD.bazel
+++ b/snapshots/go/pkg/tagger/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "tagger",
@@ -6,4 +6,15 @@ go_library(
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/tagger",
     visibility = ["//visibility:public"],
     deps = ["//snapshots/go/pkg/storage"],
+)
+
+go_test(
+    name = "tagger_test",
+    srcs = ["tagger_test.go"],
+    embed = [":tagger"],
+    deps = [
+        "//snapshots/go/pkg/storage",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/snapshots/go/pkg/tagger/tagger.go
+++ b/snapshots/go/pkg/tagger/tagger.go
@@ -9,38 +9,41 @@ import (
 	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
 )
 
-type tagger struct{}
+type Storage interface {
+	WriteAll(ctx context.Context, location string, data []byte) error
+	Stat(ctx context.Context, location string) (*storage.ObjectMetadata, error)
+}
 
-func NewTagger() *tagger {
-	return &tagger{}
+var _ Storage = (*storage.Storage)(nil)
+
+type tagger struct {
+	store Storage
+}
+
+func NewTagger(store Storage) *tagger {
+	return &tagger{store: store}
 }
 
 type TagArgs struct {
 	SnapshotName string
-	StorageUrl   string
 	TagName      string
 }
 
-func (*tagger) Tag(ctx context.Context, args *TagArgs) (*storage.ObjectMetadata, error) {
-	store, err := storage.NewStorage(args.StorageUrl)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create storage client: %w", err)
-	}
-
+func (t *tagger) Tag(ctx context.Context, args *TagArgs) (*storage.ObjectMetadata, error) {
 	snapshotLocation := fmt.Sprintf("snapshots/%s.json", args.SnapshotName)
 
-	attrs, err := store.Stat(ctx, snapshotLocation)
+	attrs, err := t.store.Stat(ctx, snapshotLocation)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get snapshot: %w", err)
 	}
 
 	tagContent := []byte(strings.TrimSuffix(path.Base(attrs.Path), ".json"))
 	tagLocation := fmt.Sprintf("tags/%s", args.TagName)
-	if err := store.WriteAll(ctx, tagLocation, tagContent); err != nil {
+	if err := t.store.WriteAll(ctx, tagLocation, tagContent); err != nil {
 		return nil, fmt.Errorf("failed to write tag: %w", err)
 	}
 
-	obj, err := store.Stat(ctx, tagLocation)
+	obj, err := t.store.Stat(ctx, tagLocation)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get object details: %w", err)
 	}

--- a/snapshots/go/pkg/tagger/tagger_test.go
+++ b/snapshots/go/pkg/tagger/tagger_test.go
@@ -1,0 +1,30 @@
+package tagger
+
+import (
+	"testing"
+
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTag(t *testing.T) {
+	store, err := storage.NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	require.NoError(t, store.WriteAll(
+		t.Context(), "snapshots/foo.json", []byte(`{"test":"data"}`)))
+
+	tagger := NewTagger(store)
+	md, err := tagger.Tag(t.Context(), &TagArgs{
+		SnapshotName: "foo",
+		TagName:      "latest",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "tags/latest", md.Path)
+
+	gotTag, err := store.ReadAll(t.Context(), "tags/latest")
+	require.NoError(t, err)
+	assert.Equal(t, "foo", string(gotTag))
+}


### PR DESCRIPTION
Change the tagger implementation to accept a storage interface,
allowing for easier testing with a fake storage implementation.

The command implementation is now responsible for
injecting the storage client into the tagger.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cognitedata/bazel-snapshots/300)
<!-- Reviewable:end -->
