### PR TITLE
refac(pusher): decouple from storage implementation

### DIFF
--- a/snapshots/go/cmd/snapshots/push.go
+++ b/snapshots/go/cmd/snapshots/push.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/models"
 	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/pusher"
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
 )
 
 type pushCmd struct {
@@ -99,12 +100,16 @@ func (pc *pushCmd) runPush(cmd *cobra.Command, args []string) error {
 	log.Printf("workspace: %s", pc.workspacePath)
 	log.Printf("storage:    %s", pc.storageURL)
 
-	pushArgs := pusher.PushArgs{
-		Name:       pc.name,
-		StorageUrl: pc.storageURL,
-		Snapshot:   pc.snapshot,
+	store, err := storage.NewStorage(pc.storageURL)
+	if err != nil {
+		return fmt.Errorf("open storage client: %w", err)
 	}
-	obj, err := pusher.NewPusher().Push(ctx, &pushArgs)
+
+	pushArgs := pusher.PushArgs{
+		Name:     pc.name,
+		Snapshot: pc.snapshot,
+	}
+	obj, err := pusher.NewPusher(store).Push(ctx, &pushArgs)
 	if err != nil {
 		return err
 	}

--- a/snapshots/go/pkg/pusher/BUILD.bazel
+++ b/snapshots/go/pkg/pusher/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "pusher",
@@ -8,5 +8,17 @@ go_library(
     deps = [
         "//snapshots/go/pkg/models",
         "//snapshots/go/pkg/storage",
+    ],
+)
+
+go_test(
+    name = "pusher_test",
+    srcs = ["pusher_test.go"],
+    embed = [":pusher"],
+    deps = [
+        "//snapshots/go/pkg/models",
+        "//snapshots/go/pkg/storage",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/snapshots/go/pkg/pusher/pusher_test.go
+++ b/snapshots/go/pkg/pusher/pusher_test.go
@@ -1,0 +1,48 @@
+package pusher
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/models"
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPush(t *testing.T) {
+	store, err := storage.NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	name := rand.Text()
+
+	pusher := NewPusher(store)
+	md, err := pusher.Push(t.Context(), &PushArgs{
+		Name: name,
+		Snapshot: &models.Snapshot{
+			Labels: map[string]*models.Tracker{
+				"//path/to:tracker": {
+					Digest: "1234abc",
+					Run: []string{
+						"//path/to:release",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, md.Path, "snapshots/"+name+".json")
+
+	body, err := store.ReadAll(t.Context(), md.Path)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"labels": {
+			"//path/to:tracker": {
+				"digest": "1234abc",
+				"run": [
+					"//path/to:release"
+				]
+			}
+		}
+	}`, string(body))
+}


### PR DESCRIPTION
Change the pusher to accept a storage interface,
allowing for easier testing with a fake storage implementation.

The command implementation is now responsible for
injecting the storage client into the pusher.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cognitedata/bazel-snapshots/301)
<!-- Reviewable:end -->
