### PR TITLE
refac(getter): decouple from storage implementation

### DIFF
--- a/snapshots/go/cmd/snapshots/get.go
+++ b/snapshots/go/cmd/snapshots/get.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/getter"
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
 )
 
 type getCmd struct {
@@ -66,13 +67,17 @@ func (gc *getCmd) runGet(cmd *cobra.Command, args []string) error {
 
 	ctx := context.Background()
 
-	getArgs := getter.GetArgs{
-		Name:       gc.name,
-		StorageURL: gc.storageURL,
-		SkipNames:  gc.skipNames,
-		SkipTags:   gc.skipTags,
+	store, err := storage.NewStorage(gc.storageURL)
+	if err != nil {
+		return fmt.Errorf("open storage: %w", err)
 	}
-	snapshot, err := getter.NewGetter().Get(ctx, &getArgs)
+
+	getArgs := getter.GetArgs{
+		Name:      gc.name,
+		SkipNames: gc.skipNames,
+		SkipTags:  gc.skipTags,
+	}
+	snapshot, err := getter.NewGetter(store).Get(ctx, &getArgs)
 	if err != nil {
 		return err
 	}

--- a/snapshots/go/pkg/getter/BUILD.bazel
+++ b/snapshots/go/pkg/getter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "getter",
@@ -8,5 +8,16 @@ go_library(
     deps = [
         "//snapshots/go/pkg/models",
         "//snapshots/go/pkg/storage",
+    ],
+)
+
+go_test(
+    name = "getter_test",
+    srcs = ["getter_test.go"],
+    embed = [":getter"],
+    deps = [
+        "//snapshots/go/pkg/storage",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/snapshots/go/pkg/getter/getter_test.go
+++ b/snapshots/go/pkg/getter/getter_test.go
@@ -1,0 +1,66 @@
+package getter
+
+import (
+	"testing"
+
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet(t *testing.T) {
+	store, err := storage.NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	files := map[string]string{
+		"snapshots/abc123.json": `{"labels": {"//foo": {"digest": "abc123", "run": ["//foo:deploy"]}}}`,
+		"snapshots/abc456.json": `{"labels": {"//foo": {"digest": "abc456", "run": ["//foo:deploy"]}}}`,
+		"tags/latest":           "abc456",
+		"tags/broken":           "nonexistent",
+	}
+	for file, content := range files {
+		err := store.WriteAll(t.Context(), file, []byte(content))
+		require.NoError(t, err)
+	}
+
+	getter := NewGetter(store)
+
+	t.Run("ByTag", func(t *testing.T) {
+		snapshot, err := getter.Get(t.Context(), &GetArgs{Name: "latest"})
+		require.NoError(t, err)
+		require.NotNil(t, snapshot)
+		require.Equal(t, "abc456", snapshot.Labels["//foo"].Digest)
+	})
+
+	t.Run("ByName", func(t *testing.T) {
+		snapshot, err := getter.Get(t.Context(), &GetArgs{Name: "abc123", SkipTags: true})
+		require.NoError(t, err)
+		require.NotNil(t, snapshot)
+		require.Equal(t, "abc123", snapshot.Labels["//foo"].Digest)
+	})
+
+	t.Run("ByNamePrefix", func(t *testing.T) {
+		snapshot, err := getter.Get(t.Context(), &GetArgs{Name: "abc1", SkipTags: true})
+		require.NoError(t, err)
+		require.NotNil(t, snapshot)
+		require.Equal(t, "abc123", snapshot.Labels["//foo"].Digest)
+	})
+
+	t.Run("ByNameAmbiguous", func(t *testing.T) {
+		_, err := getter.Get(t.Context(), &GetArgs{Name: "abc", SkipTags: true})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "ambiguous snapshot name")
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		_, err := getter.Get(t.Context(), &GetArgs{Name: "nonexistent"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("BrokenTag", func(t *testing.T) {
+		_, err := getter.Get(t.Context(), &GetArgs{Name: "broken"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "find resolved snapshot")
+	})
+}


### PR DESCRIPTION
Change the getter implementation to accept a storage interface,
allowing for easier testing with a fake storage implementation.

The command implementation is now responsible for
injecting the storage client into the tagger.

As a result of this, the "diff" command also just instantiates
the client just once instead of for each snapshot resolution.

Similar to prior refactors (#301, #300).
