### PR TITLE
Drop need of --legacy_important_outputs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,8 +2,4 @@
 build --verbose_failures
 test --test_output=errors
 
-# Docs: Use this to suppress generation of the legacy important_outputs field in the TargetComplete event. important_outputs are required for Bazel to ResultStore/BTX integration.
-# This output is used by bazel-snapshots. This flag will be removed in Bazel 9, and we'll have to update snapshots before then.
-common --legacy_important_outputs
-
 try-import %workspace%/user.bazelrc

--- a/snapshots/go/pkg/bazel/buildevents.go
+++ b/snapshots/go/pkg/bazel/buildevents.go
@@ -4,21 +4,37 @@ package bazel
 
 type BuildEventOutput struct {
 	ID struct {
+		NamedSet struct {
+			ID string `json:"id"`
+		}
 		TargetCompleted struct {
 			Label string `json:"label"`
 		}
 	}
+
+	NamedSetOfFiles NamedSetOfFiles `json:"namedSetOfFiles"`
+
 	Completed struct {
 		Success      bool `json:"success"`
 		OutputGroups []struct {
-			Name string `json:"name"`
+			Name     string `json:"name"`
+			FileSets []struct {
+				ID string `json:"id"`
+			} `json:"fileSets"`
 		} `json:"outputGroup"`
-		ImportantOutput []ImportantOutput `json:"importantOutput"`
 	}
 }
 
-type ImportantOutput struct {
-	Name       string   `json:"name"`
-	URI        string   `json:"uri"`
-	PathPrefix []string `json:"pathPrefix"`
+type NamedSetOfFiles struct {
+	Files    []NamedSetOfFilesFile    `json:"files"`
+	FileSets []NamedSetOfFilesFileSet `json:"fileSets"`
+}
+
+type NamedSetOfFilesFile struct {
+	Name string `json:"name"`
+	URI  string `json:"uri"`
+}
+
+type NamedSetOfFilesFileSet struct {
+	ID string `json:"id"`
 }

--- a/snapshots/go/pkg/collecter/BUILD.bazel
+++ b/snapshots/go/pkg/collecter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "collecter",
@@ -13,5 +13,15 @@ go_library(
         "//snapshots/go/pkg/cache",
         "//snapshots/go/pkg/models",
         "@org_golang_google_grpc//metadata",
+    ],
+)
+
+go_test(
+    name = "collecter_test",
+    srcs = ["collecter_test.go"],
+    embed = [":collecter"],
+    deps = [
+        "//snapshots/go/pkg/bazel",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/snapshots/go/pkg/collecter/collecter_test.go
+++ b/snapshots/go/pkg/collecter/collecter_test.go
@@ -1,0 +1,110 @@
+package collecter
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/bazel"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamedSetOfFiles(t *testing.T) {
+	type fileSetEvent struct {
+		ID    string
+		Files bazel.NamedSetOfFiles
+	}
+
+	tests := []struct {
+		name string
+		give []fileSetEvent
+		want map[string][]string // id -> []files
+	}{
+		{
+			name: "UnknownFileSet",
+			want: map[string][]string{
+				"0": {},
+			},
+		},
+		{
+			name: "FileSetWithFiles",
+			give: []fileSetEvent{
+				{
+					ID: "0",
+					Files: bazel.NamedSetOfFiles{
+						Files: []bazel.NamedSetOfFilesFile{
+							{Name: "a", URI: "file:///a"},
+							{Name: "b", URI: "file:///b"},
+						},
+					},
+				},
+			},
+			want: map[string][]string{
+				"0": {"file:///a", "file:///b"},
+			},
+		},
+		{
+			name: "FileSetWithNestedFileSets",
+			give: []fileSetEvent{
+				{
+					ID: "0",
+					Files: bazel.NamedSetOfFiles{
+						Files: []bazel.NamedSetOfFilesFile{
+							{Name: "a", URI: "file:///a"},
+							{Name: "b", URI: "file:///b"},
+						},
+					},
+				},
+				{
+					ID: "1",
+					Files: bazel.NamedSetOfFiles{
+						Files: []bazel.NamedSetOfFilesFile{
+							{Name: "c", URI: "file:///c"},
+						},
+						FileSets: []bazel.NamedSetOfFilesFileSet{
+							{ID: "0"},
+						},
+					},
+				},
+				{
+					ID: "2",
+					Files: bazel.NamedSetOfFiles{
+						Files: []bazel.NamedSetOfFilesFile{
+							{Name: "d", URI: "file:///d"},
+						},
+					},
+				},
+				{
+					ID: "3",
+					Files: bazel.NamedSetOfFiles{
+						FileSets: []bazel.NamedSetOfFilesFileSet{
+							{ID: "1"},
+							{ID: "2"},
+						},
+					},
+				},
+			},
+			want: map[string][]string{
+				"0": {"file:///a", "file:///b"},
+				"1": {"file:///c", "file:///a", "file:///b"},
+				"2": {"file:///d"},
+				"3": {"file:///c", "file:///a", "file:///b", "file:///d"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := make(namedSetsOfFiles)
+			for _, ev := range tt.give {
+				files.Put(ev.ID, ev.Files)
+			}
+
+			for id, wantFiles := range tt.want {
+				got := slices.Collect(files.ByID(id))
+
+				// It's a set so file order is not guaranteed.
+				assert.ElementsMatch(t, wantFiles, got, "files for id %q", id)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`--legacy_important_outputs` is deprecated.
Instead, Bazel exposes the NamedSetOfFiles event.
Details are available at
https://bazel.build/remote/bep-examples#consuming-namedsetoffiles
but in short:

- BEP includes NamedSetOfFiles events as the build progresses.
  Each NamedSetOfFiles has a unique ID.
- TargetCompleted events reference NamedSetOfFiles by ID.
- NamedSetOfFiles events may reference other NamedSetOfFiles.
- It is guaranteed that a NamedSetOfFiles event will come before
  any TargetCompleted or NamedSetOfFiles event that references it.

So the logic for traversing them is:
buffer NamedSetOfFiles events in memory,
and search through them when we see a TargetCompleted event.

Testing:
Besides included tests, I pulled this into a local Bazel workspace
with `local_path_override`,
and verified that `snapshots collect` works
even without the `--legacy_important_outputs` build flag.

Additionally, in examples/change-tracker:

```
❯ bazel run snapshots -- collect
[..]
snapshots: got 2 change trackers
{
  "labels": {
    "//:artifact_change_tracker": {
      "digest": "6244db3ebf208f21526de3e458d396e3802eb6903ff8d5911a0a90bb21837a2c",
      "run": [
        "//:deploy"
      ],
      "tags": [
        "deployable_artifact"
      ]
    },
    "//:source_file_change_tracker": {
      "digest": "0b56833a59b022841e651f8eb8528f3e43fd97ef4fda772e93e96740176b547d",
      "run": [
        "//:deploy"
      ],
      "tags": [
        "deployable_source_file"
      ]
    }
  }
}
```

Resolves #164
Resolves #165 (related code has been removed)
Resolves #303
