### PR TITLE
Prepare CI action for merge queue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: ci
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
After merging this we can enable the merge queue in the branch protection settings.